### PR TITLE
Implement worker-side image blending

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 BASE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST_DIR:=$(BASE_DIR)dist/libraries
 
+GLOBAL_CFLAGS:=-O3
+
 all: subtitleoctopus
 
 subtitleoctopus: dist
@@ -23,8 +25,7 @@ dist/libraries/lib/libfribidi.a: lib/fribidi/configure
 	emconfigure ./configure \
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
-		-O2 \
-		-s NO_FILESYSTEM=1 \
+		$(GLOBAL_CFLAGS) \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -54,8 +55,7 @@ dist/libraries/lib/libexpat.a: lib/expat/expat/configured
 	emconfigure cmake \
 		-DCMAKE_C_FLAGS=" \
 		-s USE_PTHREADS=0 \
-		-O2 \
-		-s NO_FILESYSTEM=1 \
+		$(GLOBAL_CFLAGS) \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -84,7 +84,7 @@ dist/libraries/lib/libbrotlidec.a: lib/brotli/configured
 	cd lib/brotli/build && \
 	emconfigure cmake \
 		-DCMAKE_C_FLAGS=" \
-		-O2 \
+		$(GLOBAL_CFLAGS) \
 		" \
 		-DCMAKE_INSTALL_PREFIX=$(DIST_DIR) \
 		.. \
@@ -107,8 +107,7 @@ lib/freetype/build_hb/dist_hb/lib/libfreetype.a: dist/libraries/lib/libbrotlidec
 	emconfigure ../configure \
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
-		-O2 \
-		-s NO_FILESYSTEM=1 \
+		$(GLOBAL_CFLAGS) \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -143,8 +142,7 @@ dist/libraries/lib/libharfbuzz.a: lib/freetype/build_hb/dist_hb/lib/libfreetype.
 	emconfigure ./configure \
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
-		-O2 \
-		-s NO_FILESYSTEM=1 \
+		$(GLOBAL_CFLAGS) \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -179,8 +177,7 @@ dist/libraries/lib/libfreetype.a: dist/libraries/lib/libharfbuzz.a dist/librarie
 	emconfigure ./configure \
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
-		-O2 \
-		-s NO_FILESYSTEM=1 \
+		$(GLOBAL_CFLAGS) \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -217,7 +214,7 @@ dist/libraries/lib/libfontconfig.a: dist/libraries/lib/libharfbuzz.a dist/librar
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
 		-DEMSCRIPTEN \
-		-O2 \
+		$(GLOBAL_CFLAGS) \
 		-s NO_EXIT_RUNTIME=1 \
 		--llvm-lto 1 \
 		-s STRICT=1 \
@@ -250,7 +247,7 @@ dist/libraries/lib/libass.a: dist/libraries/lib/libfontconfig.a dist/libraries/l
 	emconfigure ./configure \
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
-		-O2 \
+		$(GLOBAL_CFLAGS) \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -280,20 +277,20 @@ OCTP_DEPS = \
 	$(DIST_DIR)/lib/libfontconfig.a \
 	$(DIST_DIR)/lib/libass.a
 
-src/Makefile:
+src/Makefile: dist/libraries/lib/libass.a
 	cd src && \
-	autoreconf -fi
-
-src/subtitles-octopus-worker.bc: dist/libraries/lib/libass.a src/Makefile
-	cd src && \
+	autoreconf -fi && \
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
-	emconfigure ./configure --host=x86-none-linux --build=x86_64 CFLAGS='-g -O3 -fsanitize=undefined -s SAFE_HEAP=1'  && \
+	emconfigure ./configure --host=x86-none-linux --build=x86_64 CFLAGS="$(GLOBAL_CFLAGS)"
+
+src/subtitles-octopus-worker.bc: src/Makefile src/subtitles-octopus-worker.c
+	cd src && \
 	emmake make -j8 && \
 	mv subtitlesoctopus subtitles-octopus-worker.bc
 
 # Dist Files
 EMCC_COMMON_ARGS = \
-	-O3 \
+	$(GLOBAL_CFLAGS) \
 	-s EXPORTED_FUNCTIONS="['_main', '_malloc', '_libassjs_init', '_libassjs_quit', '_libassjs_resize', '_libassjs_render', '_libassjs_free_track', '_libassjs_create_track', '_libassjs_render_blend', '_free']" \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createFolder']" \
 	-s NO_EXIT_RUNTIME=1 \
@@ -304,9 +301,6 @@ EMCC_COMMON_ARGS = \
 	-s STRICT=1 \
 	-s FORCE_FILESYSTEM=1 \
 	--llvm-lto 1 \
-	-g \
-	-fsanitize=undefined \
-	-s SAFE_HEAP=1 \
 	--no-heap-copy \
 	-o $@
 	#--js-opts 0 -g4 \
@@ -322,6 +316,7 @@ dist/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc
 		--pre-js src/unbrotli.js \
 		--post-js src/post-worker.js \
 		-s WASM=1 \
+		--source-map-base http://localhost:8080/assets/js/ \
 		$(EMCC_COMMON_ARGS)
 
 dist/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc
@@ -333,7 +328,7 @@ dist/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc
 		-s LEGACY_VM_SUPPORT=1 \
 		$(EMCC_COMMON_ARGS)
 
-dist/subtitles-octopus.js:
+dist/subtitles-octopus.js: src/subtitles-octopus.js
 	cp src/subtitles-octopus.js dist/
 
 # Clean Tasks

--- a/Makefile
+++ b/Makefile
@@ -293,8 +293,8 @@ src/subtitles-octopus-worker.bc: dist/libraries/lib/libass.a src/Makefile
 
 # Dist Files
 EMCC_COMMON_ARGS = \
-	-O2 \
-	-s EXPORTED_FUNCTIONS="['_main', '_malloc', '_libassjs_init', '_libassjs_quit', '_libassjs_resize', '_libassjs_render', '_libassjs_free_track', '_libassjs_create_track']" \
+	-O3 \
+	-s EXPORTED_FUNCTIONS="['_main', '_malloc', '_libassjs_init', '_libassjs_quit', '_libassjs_resize', '_libassjs_render', '_libassjs_free_track', '_libassjs_create_track', '_libassjs_render_blend', '_free']" \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createFolder']" \
 	-s NO_EXIT_RUNTIME=1 \
 	--use-preload-plugins \

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ dist/libraries/lib/libfribidi.a: lib/fribidi/configure
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
+		-s NO_FILESYSTEM=1 \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -56,6 +57,7 @@ dist/libraries/lib/libexpat.a: lib/expat/expat/configured
 		-DCMAKE_C_FLAGS=" \
 		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
+		-s NO_FILESYSTEM=1 \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -108,6 +110,7 @@ lib/freetype/build_hb/dist_hb/lib/libfreetype.a: dist/libraries/lib/libbrotlidec
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
+		-s NO_FILESYSTEM=1 \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -143,6 +146,7 @@ dist/libraries/lib/libharfbuzz.a: lib/freetype/build_hb/dist_hb/lib/libfreetype.
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
+		-s NO_FILESYSTEM=1 \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -178,6 +182,7 @@ dist/libraries/lib/libfreetype.a: dist/libraries/lib/libharfbuzz.a dist/librarie
 		CFLAGS=" \
 		-s USE_PTHREADS=0 \
 		$(GLOBAL_CFLAGS) \
+		-s NO_FILESYSTEM=1 \
 		-s NO_EXIT_RUNTIME=1 \
 		-s STRICT=1 \
 		--llvm-lto 1 \
@@ -310,16 +315,15 @@ EMCC_COMMON_ARGS = \
 
 dist: src/subtitles-octopus-worker.bc dist/subtitles-octopus-worker.js dist/subtitles-octopus-worker-legacy.js dist/subtitles-octopus.js
 
-dist/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc
+dist/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc src/pre-worker.js src/unbrotli.js src/post-worker.js
 	emcc src/subtitles-octopus-worker.bc $(OCTP_DEPS) \
 		--pre-js src/pre-worker.js \
 		--pre-js src/unbrotli.js \
 		--post-js src/post-worker.js \
 		-s WASM=1 \
-		--source-map-base http://localhost:8080/assets/js/ \
 		$(EMCC_COMMON_ARGS)
 
-dist/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc
+dist/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc src/pre-worker.js src/unbrotli.js src/post-worker.js
 	emcc src/subtitles-octopus-worker.bc $(OCTP_DEPS) \
 		--pre-js src/pre-worker.js \
 		--pre-js src/unbrotli.js \

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ src/Makefile:
 src/subtitles-octopus-worker.bc: dist/libraries/lib/libass.a src/Makefile
 	cd src && \
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
-	emconfigure ./configure --host=x86-none-linux --build=x86_64 && \
+	emconfigure ./configure --host=x86-none-linux --build=x86_64 CFLAGS='-g -O3 -fsanitize=undefined -s SAFE_HEAP=1'  && \
 	emmake make -j8 && \
 	mv subtitlesoctopus subtitles-octopus-worker.bc
 
@@ -304,7 +304,10 @@ EMCC_COMMON_ARGS = \
 	-s STRICT=1 \
 	-s FORCE_FILESYSTEM=1 \
 	--llvm-lto 1 \
-	-g1 \
+	-g \
+	-fsanitize=undefined \
+	-s SAFE_HEAP=1 \
+	--no-heap-copy \
 	-o $@
 	#--js-opts 0 -g4 \
 	#--closure 1 \

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -200,6 +200,38 @@ self.render = function (force) {
     }
 };
 
+self.blendRender = function (force) {
+    self.rafId = 0;
+    self.renderPending = false;
+    var startTime = performance.now();
+
+    var renderResult = self._render_blend(self.getCurrentTime() + self.delay, force ? 1 : 0,
+                                          self.blendX, self.blendY, self.blendW, self.blendH);
+    if (renderResult) {
+        var blendX = Module.getValue(self.blendX, 'i32');
+        var blendY = Module.getValue(self.blendY, 'i32');
+        var blendW = Module.getValue(self.blendW, 'i32');
+        var blendH = Module.getValue(self.blendH, 'i32');
+        // make a copy, as we should free the memory so subsequent calls can utilize it
+        var result = new HEAPU8.slice(renderResult, renderResult + blendW * blendH * 4);
+        Module._free(renderResult);
+        var spentTime = performance.now() - startTime;
+
+        var elem = {w: blendW, h: blendH, x: blendX, y: blendY, buffer: result.buffer};
+        postMessage({
+            target: 'canvas',
+            op: 'renderCanvas',
+            time: Date.now(),
+            spentTime: spentTime,
+            canvases: [elem]
+        }, [result.buffer]);
+    }
+
+    if (!self._isPaused) {
+        self.rafId = self.requestAnimationFrame(self.render);
+    }
+};
+
 self.fastRender = function (force) {
     self.rafId = 0;
     self.renderPending = false;

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -195,25 +195,34 @@ self.blendRender = function (force) {
     var startTime = performance.now();
 
     var renderResult = self._render_blend(self.getCurrentTime() + self.delay, force ? 1 : 0,
+                                          self.changed, self.blendTime,
                                           self.blendX, self.blendY, self.blendW, self.blendH);
-    if (renderResult) {
-        var blendX = Module.getValue(self.blendX, 'i32');
-        var blendY = Module.getValue(self.blendY, 'i32');
-        var blendW = Module.getValue(self.blendW, 'i32');
-        var blendH = Module.getValue(self.blendH, 'i32');
-        // make a copy, as we should free the memory so subsequent calls can utilize it
-        var result = new Uint8Array(HEAPU8.subarray(renderResult, renderResult + blendW * blendH * 4));
-        Module._free(renderResult);
-        var spentTime = performance.now() - startTime;
+    var changed = Module.getValue(self.changed, 'i32');
+    var blendTime = Module.getValue(self.blendTime, 'double');
+    if (changed != 0 || force) {
+        var canvases, buffers;
+        if (renderResult) {
+            var blendX = Module.getValue(self.blendX, 'i32');
+            var blendY = Module.getValue(self.blendY, 'i32');
+            var blendW = Module.getValue(self.blendW, 'i32');
+            var blendH = Module.getValue(self.blendH, 'i32');
+            // make a copy, as we should free the memory so subsequent calls can utilize it
+            var result = new Uint8Array(HEAPU8.subarray(renderResult, renderResult + blendW * blendH * 4));
+            Module._free(renderResult);
 
-        var elem = {w: blendW, h: blendH, x: blendX, y: blendY, buffer: result.buffer};
+            canvases = [{w: blendW, h: blendH, x: blendX, y: blendY, buffer: result.buffer}];
+            buffers = [result.buffer];
+        } else {
+            canvases = buffers = [];
+        }
         postMessage({
             target: 'canvas',
             op: 'renderCanvas',
             time: Date.now(),
-            spentTime: spentTime,
-            canvases: [elem]
-        }, [result.buffer]);
+            spentTime: performance.now() - startTime,
+            blendTime: blendTime,
+            canvases: canvases
+        }, buffers);
     }
 
     if (!self._isPaused) {

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -534,7 +534,6 @@ function onMessageFromMainEmscriptenThread(message) {
             self.subContent = message.data.subContent;
             self.fontFiles = message.data.fonts;
             self.renderMode = message.data.renderMode;
-            //self.fastRenderMode = message.data.fastRender;
             self.availableFonts = message.data.availableFonts;
             self.debug = message.data.debug;
             if (!hasNativeConsole && self.debug) {

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -61,6 +61,16 @@ self.writeAvailableFontsToFS = function(content) {
     }
 };
 
+self.getRenderMethod = function () {
+    if (self.renderMode == 'fast') {
+        return self.fastRender;
+    } else if (self.renderMode == 'blend') {
+        return self.blendRender;
+    } else {
+        return self.render;
+    }
+}
+
 /**
  * Set the subtitle track.
  * @param {!string} content the content of the subtitle file.
@@ -74,11 +84,7 @@ self.setTrack = function (content) {
 
     // Tell libass to render the new track
     self._create_track("/sub.ass");
-    if (self.fastRenderMode) {
-        self.fastRender();
-    } else {
-        self.render();
-    }
+    self.getRenderMethod()();
 };
 
 /**
@@ -86,11 +92,7 @@ self.setTrack = function (content) {
  */
 self.freeTrack = function () {
     self._free_track();
-    if (self.fastRenderMode) {
-        self.fastRender();
-    } else {
-        self.render();
-    }
+    self.getRenderMethod()();
 };
 
 /**
@@ -131,18 +133,10 @@ self.setCurrentTime = function (currentTime) {
     self.lastCurrentTimeReceivedAt = Date.now();
     if (!self.rafId) {
         if (self.nextIsRaf) {
-            if (self.fastRenderMode) {
-                self.rafId = self.requestAnimationFrame(self.fastRender);
-            } else {
-                self.rafId = self.requestAnimationFrame(self.render);
-            }
+            self.rafId = self.requestAnimationFrame(self.getRenderMethod());
         }
         else {
-            if (self.fastRenderMode) {
-                self.fastRender();
-            } else {
-                self.render();
-            }
+            self.getRenderMethod()();
             
             // Give onmessage chance to receive all queued messages
             setTimeout(function () {
@@ -167,12 +161,7 @@ self.setIsPaused = function (isPaused) {
         }
         else {
             self.lastCurrentTimeReceivedAt = Date.now();
-            if (self.fastRenderMode) {
-                self.rafId = self.requestAnimationFrame(self.fastRender);
-            } else {
-                self.rafId = self.requestAnimationFrame(self.render);
-            }
-            
+            self.rafId = self.requestAnimationFrame(self.getRenderMethod());
         }
     }
 };
@@ -508,11 +497,7 @@ function onMessageFromMainEmscriptenThread(message) {
                     Module.canvas.boundingClientRect = message.data.boundingClientRect;
                 }
                 self.resize(message.data.width, message.data.height);
-                if (self.fastRenderMode) {
-                    self.fastRender();
-                } else {
-                    self.render();
-                }
+                self.getRenderMethod()();
             } else throw 'ey?';
             break;
         }
@@ -539,7 +524,8 @@ function onMessageFromMainEmscriptenThread(message) {
             self.subUrl = message.data.subUrl;
             self.subContent = message.data.subContent;
             self.fontFiles = message.data.fonts;
-            self.fastRenderMode = message.data.fastRender;
+            self.renderMode = message.data.renderMode;
+            //self.fastRenderMode = message.data.fastRender;
             self.availableFonts = message.data.availableFonts;
             self.debug = message.data.debug;
             if (!hasNativeConsole && self.debug) {

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -202,7 +202,7 @@ self.blendRender = function (force) {
         var blendW = Module.getValue(self.blendW, 'i32');
         var blendH = Module.getValue(self.blendH, 'i32');
         // make a copy, as we should free the memory so subsequent calls can utilize it
-        var result = new HEAPU8.slice(renderResult, renderResult + blendW * blendH * 4);
+        var result = new Uint8Array(HEAPU8.subarray(renderResult, renderResult + blendW * blendH * 4));
         Module._free(renderResult);
         var spentTime = performance.now() - startTime;
 
@@ -217,7 +217,7 @@ self.blendRender = function (force) {
     }
 
     if (!self._isPaused) {
-        self.rafId = self.requestAnimationFrame(self.render);
+        self.rafId = self.requestAnimationFrame(self.blendRender);
     }
 };
 

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -97,8 +97,16 @@ Module['onRuntimeInitialized'] = function () {
     self._render = Module['cwrap']('libassjs_render', null, ['number', 'number']);
     self._free_track = Module['cwrap']('libassjs_free_track', null, null);
     self._create_track = Module['cwrap']('libassjs_create_track', null, ['string']);
+
+    self._render_blend = Module['cwrap']('libassjs_render_blend', null, ['number', 'number', 'number', 'number', 'number', 'number']);
+
     self.quit = Module['cwrap']('libassjs_quit', null, []);
     self.changed = Module._malloc(4);
+
+    self.blendX = Module._malloc(4);
+    self.blendY = Module._malloc(4);
+    self.blendW = Module._malloc(4);
+    self.blendH = Module._malloc(4);
 
     self.init(screen.width, screen.height, "/sub.ass");
 };

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -98,11 +98,12 @@ Module['onRuntimeInitialized'] = function () {
     self._free_track = Module['cwrap']('libassjs_free_track', null, null);
     self._create_track = Module['cwrap']('libassjs_create_track', null, ['string']);
 
-    self._render_blend = Module['cwrap']('libassjs_render_blend', null, ['number', 'number', 'number', 'number', 'number', 'number']);
+    self._render_blend = Module['cwrap']('libassjs_render_blend', null, ['number', 'number', 'number', 'number', 'number', 'number', 'number', 'number']);
 
     self.quit = Module['cwrap']('libassjs_quit', null, []);
     self.changed = Module._malloc(4);
 
+    self.blendTime = Module._malloc(8);
     self.blendX = Module._malloc(4);
     self.blendY = Module._malloc(4);
     self.blendW = Module._malloc(4);

--- a/src/subtitles-octopus-worker.c
+++ b/src/subtitles-octopus-worker.c
@@ -128,7 +128,7 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
     {
         int curw = cur->w, curh = cur->h;
         if (curw == 0 || curh == 0) continue; // skip empty images
-        int curs = cur->stride, curx = cur->dst_x, cury = cur->dst_y;
+        int curs = (cur->stride >= curw) ? cur->stride : curw, curx = cur->dst_x, cury = cur->dst_y;
         
         unsigned char *bitmap = cur->bitmap;
         float a = (cur->color & 0xFF) / 255.0;
@@ -145,6 +145,10 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
             int buf_line_coord = (cury + y) * width;
             for (int x = 0; x < curw; x++)
             {
+                // manual bounds check
+                //if (x + curx >= width) printf("libass: outside by x");
+                //if (y + cury >= height) printf("libass: outside by y");
+
                 float pix_alpha = bitmap[bitmap_offset + x] * a / 255.0;
                 float inv_alpha = 1.0 - pix_alpha;
                 
@@ -186,6 +190,7 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
     }
     
     // return the thing
+    printf("libass: returning result");
     free(buf);
     *dest_x = min_x;
     *dest_y = min_y;

--- a/src/subtitles-octopus-worker.c
+++ b/src/subtitles-octopus-worker.c
@@ -85,14 +85,18 @@ const float MAX_UINT8_CAST = 256.0 / 255;
 
 #define CLAMP_UINT8(value) ((value > MIN_UINT8_CAST) ? ((value < MAX_UINT8_CAST) ? (int)(value * 255) : 255) : 0)
 
-void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int *dest_width, int *dest_height)
+void* libassjs_render_blend(double tm, int force, int *changed, double *blend_time,
+        int *dest_x, int *dest_y, int *dest_width, int *dest_height)
 {
-    int changed;
-    ASS_Image *img = ass_render_frame(ass_renderer, track, (int)(tm * 1000), &changed);
-    if (img == NULL || (changed == 0 && !force))
+    *blend_time = 0.0;
+
+    ASS_Image *img = ass_render_frame(ass_renderer, track, (int)(tm * 1000), changed);
+    if (img == NULL || (*changed == 0 && !force))
     {
         return NULL;
     }
+
+    double start_blend_time = emscripten_get_now();
 
     // find bounding rect first
     int min_x = img->dst_x, min_y = img->dst_y;
@@ -192,6 +196,7 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
     *dest_y = min_y;
     *dest_width = width;
     *dest_height = height;
+    *blend_time = emscripten_get_now() - start_blend_time;
     return result;
 }
 

--- a/src/subtitles-octopus-worker.c
+++ b/src/subtitles-octopus-worker.c
@@ -80,6 +80,120 @@ ASS_Image * libassjs_render(double tm, int *changed)
     return img;
 }
 
+#define CLAMP_UINT8(value) ((value > 0) ? ((value <= 255) ? (int)value : 255) : 0)
+
+void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int *dest_width, int *dest_height)
+{
+    int changed;
+    ASS_Image *img = ass_render_frame(ass_renderer, track, (int)(tm * 1000), &changed);
+    if (img == NULL || (changed == 0 && !force))
+    {
+        return NULL;
+    }
+
+    // find bounding rect first
+    int min_x = img->dst_x, min_y = img->dst_y;
+    int max_x = img->dst_x + img->w - 1, max_y = img->dst_y + img->h - 1;
+    ASS_Image *cur;
+    for (cur = img->next; cur != NULL; cur = cur->next)
+    {
+        if (cur->dst_x < min_x) min_x = cur->dst_x;
+        if (cur->dst_y < min_y) min_y = cur->dst_y;
+        int right = cur->dst_x + cur->w - 1;
+        int bottom = cur->dst_y + cur->h - 1;
+        if (right > max_x) max_x = right;
+        if (bottom > max_y) max_y = bottom;
+    }
+
+    // make float buffer for blending
+    int width = max_x - min_x + 1, height = max_y - min_y + 1;
+    float* buf = (float*)malloc(sizeof(float) * width * height * 4);
+    if (buf == NULL)
+    {
+        printf("libass: error: cannot allocate buffer for blending");
+        return NULL;
+    }
+    unsigned char *result = (unsigned char*)malloc(sizeof(unsigned char) * width * height * 4);
+    if (result == NULL)
+    {
+        printf("libass: error: cannot allocate result for blending");
+        free(buf);
+        return NULL;
+    }
+    memset(buf, 0, sizeof(float) * width * height * 4);
+    memset(result, 0, sizeof(unsigned char) * width * height * 4);
+
+    // blend things in
+    for (cur = img; cur != NULL; cur = cur->next)
+    {
+        int curw = cur->w, curh = cur->h;
+        if (curw == 0 || curh == 0) continue; // skip empty images
+        int curs = cur->stride, curx = cur->dst_x, cury = cur->dst_y;
+        
+        unsigned char *bitmap = cur->bitmap;
+        float a = (cur->color & 0xFF) / 255.0;
+
+        // premultiply by alpha
+        float r = a * ((cur->color >> 24) & 0xFF) / 255.0;
+        float g = a * ((cur->color >> 16) & 0xFF) / 255.0;
+        float b = a * ((cur->color >> 8) & 0xFF) / 255.0;
+
+        // float a = (255 - (cur->color & 0xFF)) / 255.0;
+
+        for (int y = 0, bitmap_offset = 0; y < curh; y++, bitmap_offset += curs)
+        {
+            int buf_line_coord = (cury + y) * width;
+            for (int x = 0; x < curw; x++)
+            {
+                float pix_alpha = bitmap[bitmap_offset + x] * a / 255.0;
+                float inv_alpha = 1.0 - pix_alpha;
+                
+                int buf_coord = (buf_line_coord + curx + x) << 2;
+                float *buf_r = buf + buf_coord;
+                float *buf_g = buf + buf_coord + 1;
+                float *buf_b = buf + buf_coord + 2;
+                float *buf_a = buf + buf_coord + 3;
+                
+                float buf_alpha = *buf_a;
+                
+                // do the compositing
+                *buf_a = pix_alpha + buf_alpha * inv_alpha;
+                *buf_r = r + *buf_r * inv_alpha;
+                *buf_g = g + *buf_g * inv_alpha;
+                *buf_b = b + *buf_b * inv_alpha;
+            }
+        }
+    }
+    
+    // now build the result
+    for (int y = 0, buf_line_coord = 0; y < height; y++, buf_line_coord += width)
+    {
+        for (int x = 0; x < width; x++)
+        {
+            int buf_coord = (buf_line_coord + x) << 2;
+            // need to un-multiply the result
+            float alpha = buf[buf_coord + 3];
+            if (alpha > 1e-5)
+            {
+                for (int offset = 0; offset < 3; offset++)
+                {
+                    float value = buf[buf_coord + offset] / alpha;
+                    result[buf_coord + offset] = CLAMP_UINT8(value);
+                }
+                result[buf_coord + 3] = CLAMP_UINT8(alpha);
+            }
+        }
+    }
+    
+    // return the thing
+    free(buf);
+    *dest_x = min_x;
+    *dest_y = min_y;
+    *dest_width = width;
+    *dest_height = height;
+    return result;
+}
+
 int main(int argc, char *argv[])
 {
     

--- a/src/subtitles-octopus-worker.c
+++ b/src/subtitles-octopus-worker.c
@@ -80,7 +80,10 @@ ASS_Image * libassjs_render(double tm, int *changed)
     return img;
 }
 
-#define CLAMP_UINT8(value) ((value > 0) ? ((value <= 255) ? (int)value : 255) : 0)
+const float MIN_UINT8_CAST = 0.9 / 255;
+const float MAX_UINT8_CAST = 256.0 / 255;
+
+#define CLAMP_UINT8(value) ((value > MIN_UINT8_CAST) ? ((value < MAX_UINT8_CAST) ? (int)(value * 255) : 255) : 0)
 
 void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int *dest_width, int *dest_height)
 {
@@ -128,28 +131,24 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
     {
         int curw = cur->w, curh = cur->h;
         if (curw == 0 || curh == 0) continue; // skip empty images
-        int curs = (cur->stride >= curw) ? cur->stride : curw, curx = cur->dst_x, cury = cur->dst_y;
-        
+        int a = (255 - (cur->color & 0xFF));
+        if (a == 0) continue; // skip transparent images
+
+        int curs = (cur->stride >= curw) ? cur->stride : curw;
+        int curx = cur->dst_x - min_x, cury = cur->dst_y - min_y;
+
         unsigned char *bitmap = cur->bitmap;
-        float a = (cur->color & 0xFF) / 255.0;
+        float normalized_a = a / 255.0;
+        float r = ((cur->color >> 24) & 0xFF) / 255.0;
+        float g = ((cur->color >> 16) & 0xFF) / 255.0;
+        float b = ((cur->color >> 8) & 0xFF) / 255.0;
 
-        // premultiply by alpha
-        float r = a * ((cur->color >> 24) & 0xFF) / 255.0;
-        float g = a * ((cur->color >> 16) & 0xFF) / 255.0;
-        float b = a * ((cur->color >> 8) & 0xFF) / 255.0;
-
-        // float a = (255 - (cur->color & 0xFF)) / 255.0;
-
-        for (int y = 0, bitmap_offset = 0; y < curh; y++, bitmap_offset += curs)
+        int buf_line_coord = cury * width;
+        for (int y = 0, bitmap_offset = 0; y < curh; y++, bitmap_offset += curs, buf_line_coord += width)
         {
-            int buf_line_coord = (cury + y) * width;
             for (int x = 0; x < curw; x++)
             {
-                // manual bounds check
-                //if (x + curx >= width) printf("libass: outside by x");
-                //if (y + cury >= height) printf("libass: outside by y");
-
-                float pix_alpha = bitmap[bitmap_offset + x] * a / 255.0;
+                float pix_alpha = bitmap[bitmap_offset + x] * normalized_a / 255.0;
                 float inv_alpha = 1.0 - pix_alpha;
                 
                 int buf_coord = (buf_line_coord + curx + x) << 2;
@@ -158,13 +157,11 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
                 float *buf_b = buf + buf_coord + 2;
                 float *buf_a = buf + buf_coord + 3;
                 
-                float buf_alpha = *buf_a;
-                
-                // do the compositing
-                *buf_a = pix_alpha + buf_alpha * inv_alpha;
-                *buf_r = r + *buf_r * inv_alpha;
-                *buf_g = g + *buf_g * inv_alpha;
-                *buf_b = b + *buf_b * inv_alpha;
+                // do the compositing, pre-multiply image RGB with alpha for current pixel
+                *buf_a = pix_alpha + *buf_a * inv_alpha;
+                *buf_r = r * pix_alpha + *buf_r * inv_alpha;
+                *buf_g = g * pix_alpha + *buf_g * inv_alpha;
+                *buf_b = b * pix_alpha + *buf_b * inv_alpha;
             }
         }
     }
@@ -175,12 +172,12 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
         for (int x = 0; x < width; x++)
         {
             int buf_coord = (buf_line_coord + x) << 2;
-            // need to un-multiply the result
             float alpha = buf[buf_coord + 3];
-            if (alpha > 1e-5)
+            if (alpha > MIN_UINT8_CAST)
             {
                 for (int offset = 0; offset < 3; offset++)
                 {
+                    // need to un-multiply the result
                     float value = buf[buf_coord + offset] / alpha;
                     result[buf_coord + offset] = CLAMP_UINT8(value);
                 }
@@ -190,7 +187,6 @@ void* libassjs_render_blend(double tm, int force, int *dest_x, int *dest_y, int 
     }
     
     // return the thing
-    printf("libass: returning result");
     free(buf);
     *dest_x = min_x;
     *dest_y = min_y;

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -236,6 +236,7 @@ var SubtitlesOctopus = function (options) {
     function renderFrames() {
         var data = self.renderFramesData;
         var beforeDrawTime = performance.now();
+        self.ctx.clearRect(0, 0, self.canvas.width, self.canvas.height);
         for (var i = 0; i < data.canvases.length; i++) {
             var image = data.canvases[i];
             self.bufferCanvas.width = image.w;
@@ -252,7 +253,12 @@ var SubtitlesOctopus = function (options) {
         }
         if (self.debug) {
             var drawTime = Math.round(performance.now() - beforeDrawTime);
-            console.log(Math.round(data.spentTime) + ' ms (+ ' + drawTime + ' ms draw)');
+            var blendTime = data.blendTime || 0;
+            if (blendTime > 0) {
+                console.log('render: ' + Math.round(data.spentTime - blendTime) + ' ms, blend: ' + Math.round(blendTime) + ' ms, draw: ' + drawTime + ' ms');
+            } else {
+                console.log(Math.round(data.spentTime) + ' ms (+ ' + drawTime + ' ms draw)');
+            }
             self.renderStart = performance.now();
         }
     }

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -13,7 +13,7 @@ var SubtitlesOctopus = function (options) {
 
     var self = this;
     self.canvas = options.canvas; // HTML canvas element (optional if video specified)
-    self.lossyRender = options.lossyRender; // Speedup render for heavy subs
+    self.renderMode = options.lossyRender ? 'fast' : (options.blendRender ? 'blend' : 'normal');
     self.isOurCanvas = false; // (internal) we created canvas and manage it
     self.video = options.video; // HTML video element (optional if canvas specified)
     self.canvasParent = null; // (internal) HTML canvas parent element
@@ -99,7 +99,7 @@ var SubtitlesOctopus = function (options) {
             URL: document.URL,
             currentScript: self.workerUrl,
             preMain: true,
-            fastRender: self.lossyRender,
+            renderMode: self.renderMode,
             subUrl: self.subUrl,
             subContent: self.subContent,
             fonts: self.fonts,

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -236,7 +236,6 @@ var SubtitlesOctopus = function (options) {
     function renderFrames() {
         var data = self.renderFramesData;
         var beforeDrawTime = performance.now();
-        self.ctx.clearRect(0, 0, self.canvas.width, self.canvas.height);
         for (var i = 0; i < data.canvases.length; i++) {
             var image = data.canvases[i];
             self.bufferCanvas.width = image.w;


### PR DESCRIPTION
This allows to render rather complex tracks with a lot less lag, at least when running with WebAssembly.

The issue I'm addressing here (and what was causing the lags) is original implementation was blending up to several hundreds of small images on each frame in JavaScript UI thread, and to do so it created hundreds of small images out of raw data and drawn them, which turned out to be a real bottleneck (as well as it pegged the user interactions because this blending was done in same thread which interacted with the user).

I'm creating a new render mode (`blendRender`) for blending all small images in worker space (similar to what `fastRender` tried to do, but it only made images in worker thread but still blended them in UI), so UI thread is only drawing one image no matter how complex the animation is.

I've also slightly fixed the Makefile, and upped the optimization level from `-O2` to `-O3` for (hopefully) some performance boost.