### PR TITLE
Reduce heap usage

### DIFF
--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -208,7 +208,6 @@ self.blendRender = function (force) {
             var blendH = Module.getValue(self.blendH, 'i32');
             // make a copy, as we should free the memory so subsequent calls can utilize it
             var result = new Uint8Array(HEAPU8.subarray(renderResult, renderResult + blendW * blendH * 4));
-            Module._free(renderResult);
 
             canvases = [{w: blendW, h: blendH, x: blendX, y: blendY, buffer: result.buffer}];
             buffers = [result.buffer];

--- a/src/subtitles-octopus-worker.c
+++ b/src/subtitles-octopus-worker.c
@@ -28,7 +28,7 @@ void* buffer_resize(buffer_t *buf, int new_size, int keep_content) {
         } else {
             buf->lessen_counter = 0;
         }
-        if (buf->lessen_counter < 30) {
+        if (buf->lessen_counter < 10) {
             // not reducing the buffer yet
             return buf->buffer;
         }
@@ -42,6 +42,7 @@ void* buffer_resize(buffer_t *buf, int new_size, int keep_content) {
     }
     if (!newbuf) return NULL;
 
+    if (!keep_content) free(buf->buffer);
     buf->buffer = newbuf;
     buf->size = new_size;
     buf->lessen_counter = 0;


### PR DESCRIPTION
Instead of allocating and freeing buffers in each blending iteration, re-use them between calls.
Also re-use the same buffer for computing blending of images as well as for end result, this reduces heap usage even more.

Plus writing to the result as `int` instead of doing it via 4 writes of `unsigned char` should help on ARM where unaligned writes are emulated by WebAssembly engine.