### PR TITLE
Introduce "render ahead" mode which improves timing accuracy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ src/subtitles-octopus-worker.bc: $(OCTP_DEPS) src/Makefile src/SubtitleOctopus.c
 # Dist Files
 EMCC_COMMON_ARGS = \
 	$(GLOBAL_CFLAGS) \
-	-s EXPORTED_FUNCTIONS="['_main', '_malloc', '_libassjs_find_next_event_start', '_libassjs_find_event_stop_times']" \
+	-s EXPORTED_FUNCTIONS="['_main', '_malloc']" \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createFolder']" \
 	-s NO_EXIT_RUNTIME=1 \
 	--use-preload-plugins \

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ src/subtitles-octopus-worker.bc: $(OCTP_DEPS) src/Makefile src/SubtitleOctopus.c
 # Dist Files
 EMCC_COMMON_ARGS = \
 	$(GLOBAL_CFLAGS) \
-	-s EXPORTED_FUNCTIONS="['_main', '_malloc']" \
+	-s EXPORTED_FUNCTIONS="['_main', '_malloc', '_libassjs_find_next_event_start', '_libassjs_find_event_stop_times']" \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createFolder']" \
 	-s NO_EXIT_RUNTIME=1 \
 	--use-preload-plugins \

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ lib/libass/configure:
 	patch -d "$(BASE_DIR)lib/libass" -Np1 -i $(file);) \
 	NOCONFIGURE=1 ./autogen.sh
 
-dist/libraries/lib/libass.a: dist/libraries/lib/libfontconfig.a dist/libraries/lib/libharfbuzz.a dist/libraries/lib/libexpat.a dist/libraries/lib/libfribidi.a dist/libraries/lib/libfreetype.a dist/libraries/lib/libbrotlidec.a lib/libass/configure
+$(DIST_DIR)/lib/libass.a: dist/libraries/lib/libfontconfig.a dist/libraries/lib/libharfbuzz.a dist/libraries/lib/libexpat.a dist/libraries/lib/libfribidi.a dist/libraries/lib/libfreetype.a dist/libraries/lib/libbrotlidec.a lib/libass/configure
 	cd lib/libass && \
 	EM_PKG_CONFIG_PATH=$(DIST_DIR)/lib/pkgconfig \
 	emconfigure ./configure \

--- a/src/SubOctpInterface.cpp
+++ b/src/SubOctpInterface.cpp
@@ -254,6 +254,14 @@ RenderBlendResult* EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_renderBl
   return self->renderBlend(tm, force);
 }
 
+double EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_findNextEventStart_1(SubtitleOctopus* self, double tm) {
+  return self->findNextEventStart(tm);
+}
+
+EventStopTimesResult* EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_findEventStopTimes_1(SubtitleOctopus* self, double tm) {
+  return self->findEventStopTimes(tm);
+}
+
 ASS_Track* EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_get_track_0(SubtitleOctopus* self) {
   return self->track;
 }
@@ -630,6 +638,32 @@ int EMSCRIPTEN_KEEPALIVE emscripten_bind_ASS_Style_get_Justify_0(ASS_Style* self
 
 void EMSCRIPTEN_KEEPALIVE emscripten_bind_ASS_Style_set_Justify_1(ASS_Style* self, int arg0) {
   self->Justify = arg0;
+}
+
+// EventStopTimesResult
+
+double EMSCRIPTEN_KEEPALIVE emscripten_bind_EventStopTimesResult_get_eventFinish_0(EventStopTimesResult* self) {
+  return self->eventFinish;
+}
+
+void EMSCRIPTEN_KEEPALIVE emscripten_bind_EventStopTimesResult_set_eventFinish_1(EventStopTimesResult* self, double arg0) {
+  self->eventFinish = arg0;
+}
+
+double EMSCRIPTEN_KEEPALIVE emscripten_bind_EventStopTimesResult_get_emptyFinish_0(EventStopTimesResult* self) {
+  return self->emptyFinish;
+}
+
+void EMSCRIPTEN_KEEPALIVE emscripten_bind_EventStopTimesResult_set_emptyFinish_1(EventStopTimesResult* self, double arg0) {
+  self->emptyFinish = arg0;
+}
+
+int EMSCRIPTEN_KEEPALIVE emscripten_bind_EventStopTimesResult_get_is_animated_0(EventStopTimesResult* self) {
+  return self->is_animated;
+}
+
+void EMSCRIPTEN_KEEPALIVE emscripten_bind_EventStopTimesResult_set_is_animated_1(EventStopTimesResult* self, int arg0) {
+  self->is_animated = arg0;
 }
 
 // ASS_Image

--- a/src/SubOctpInterface.js
+++ b/src/SubOctpInterface.js
@@ -546,6 +546,18 @@ SubtitleOctopus.prototype['renderBlend'] = SubtitleOctopus.prototype.renderBlend
   return wrapPointer(_emscripten_bind_SubtitleOctopus_renderBlend_2(self, tm, force), RenderBlendResult);
 };;
 
+SubtitleOctopus.prototype['findNextEventStart'] = SubtitleOctopus.prototype.findNextEventStart = /** @suppress {undefinedVars, duplicate} */function(tm) {
+  var self = this.ptr;
+  if (tm && typeof tm === 'object') tm = tm.ptr;
+  return _emscripten_bind_SubtitleOctopus_findNextEventStart_1(self, tm);
+};;
+
+SubtitleOctopus.prototype['findEventStopTimes'] = SubtitleOctopus.prototype.findEventStopTimes = /** @suppress {undefinedVars, duplicate} */function(tm) {
+  var self = this.ptr;
+  if (tm && typeof tm === 'object') tm = tm.ptr;
+  return wrapPointer(_emscripten_bind_SubtitleOctopus_findEventStopTimes_1(self, tm), EventStopTimesResult);
+};;
+
   SubtitleOctopus.prototype['get_track'] = SubtitleOctopus.prototype.get_track = /** @suppress {undefinedVars, duplicate} */function() {
   var self = this.ptr;
   return wrapPointer(_emscripten_bind_SubtitleOctopus_get_track_0(self), ASS_Track);
@@ -1052,6 +1064,44 @@ Module['ASS_Style'] = ASS_Style;
   _emscripten_bind_ASS_Style_set_Justify_1(self, arg0);
 };
     Object.defineProperty(ASS_Style.prototype, 'Justify', { get: ASS_Style.prototype.get_Justify, set: ASS_Style.prototype.set_Justify });
+// EventStopTimesResult
+/** @suppress {undefinedVars, duplicate} */function EventStopTimesResult() { throw "cannot construct a EventStopTimesResult, no constructor in IDL" }
+EventStopTimesResult.prototype = Object.create(WrapperObject.prototype);
+EventStopTimesResult.prototype.constructor = EventStopTimesResult;
+EventStopTimesResult.prototype.__class__ = EventStopTimesResult;
+EventStopTimesResult.__cache__ = {};
+Module['EventStopTimesResult'] = EventStopTimesResult;
+
+  EventStopTimesResult.prototype['get_eventFinish'] = EventStopTimesResult.prototype.get_eventFinish = /** @suppress {undefinedVars, duplicate} */function() {
+  var self = this.ptr;
+  return _emscripten_bind_EventStopTimesResult_get_eventFinish_0(self);
+};
+    EventStopTimesResult.prototype['set_eventFinish'] = EventStopTimesResult.prototype.set_eventFinish = /** @suppress {undefinedVars, duplicate} */function(arg0) {
+  var self = this.ptr;
+  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
+  _emscripten_bind_EventStopTimesResult_set_eventFinish_1(self, arg0);
+};
+    Object.defineProperty(EventStopTimesResult.prototype, 'eventFinish', { get: EventStopTimesResult.prototype.get_eventFinish, set: EventStopTimesResult.prototype.set_eventFinish });
+  EventStopTimesResult.prototype['get_emptyFinish'] = EventStopTimesResult.prototype.get_emptyFinish = /** @suppress {undefinedVars, duplicate} */function() {
+  var self = this.ptr;
+  return _emscripten_bind_EventStopTimesResult_get_emptyFinish_0(self);
+};
+    EventStopTimesResult.prototype['set_emptyFinish'] = EventStopTimesResult.prototype.set_emptyFinish = /** @suppress {undefinedVars, duplicate} */function(arg0) {
+  var self = this.ptr;
+  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
+  _emscripten_bind_EventStopTimesResult_set_emptyFinish_1(self, arg0);
+};
+    Object.defineProperty(EventStopTimesResult.prototype, 'emptyFinish', { get: EventStopTimesResult.prototype.get_emptyFinish, set: EventStopTimesResult.prototype.set_emptyFinish });
+  EventStopTimesResult.prototype['get_is_animated'] = EventStopTimesResult.prototype.get_is_animated = /** @suppress {undefinedVars, duplicate} */function() {
+  var self = this.ptr;
+  return _emscripten_bind_EventStopTimesResult_get_is_animated_0(self);
+};
+    EventStopTimesResult.prototype['set_is_animated'] = EventStopTimesResult.prototype.set_is_animated = /** @suppress {undefinedVars, duplicate} */function(arg0) {
+  var self = this.ptr;
+  if (arg0 && typeof arg0 === 'object') arg0 = arg0.ptr;
+  _emscripten_bind_EventStopTimesResult_set_is_animated_1(self, arg0);
+};
+    Object.defineProperty(EventStopTimesResult.prototype, 'is_animated', { get: EventStopTimesResult.prototype.get_is_animated, set: EventStopTimesResult.prototype.set_is_animated });
 // ASS_Image
 /** @suppress {undefinedVars, duplicate} */function ASS_Image() { throw "cannot construct a ASS_Image, no constructor in IDL" }
 ASS_Image.prototype = Object.create(WrapperObject.prototype);

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -92,7 +92,7 @@ double libassjs_find_next_event_start(double tm) {
     long long now = (long long)(tm * 1000);
     long long closest = -1;
 
-    for (int i = 0; i < tracks->n_events; i++, cur++) {
+    for (int i = 0; i < track->n_events; i++, cur++) {
         long long start = cur->Start;
         if (start >= now && (start < closest || closest == -1)) {
             closest = start;

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -80,29 +80,16 @@ const float MAX_UINT8_CAST = 255.9 / 255;
 #define CLAMP_UINT8(value) ((value > MIN_UINT8_CAST) ? ((value < MAX_UINT8_CAST) ? (int)(value * 255) : 255) : 0)
 
 typedef struct {
-public:
     int changed;
     double blend_time;
     int dest_x, dest_y, dest_width, dest_height;
     unsigned char* image;
 } RenderBlendResult;
 
-double libassjs_find_next_event_start(double tm) {
-    if (!track || track->n_events == 0) return -1;
-
-    ASS_Event *cur = track->events;
-    long long now = (long long)(tm * 1000);
-    long long closest = -1;
-
-    for (int i = 0; i < track->n_events; i++, cur++) {
-        long long start = cur->Start;
-        if (start >= now && (start < closest || closest == -1)) {
-            closest = start;
-        }
-    }
-
-    return closest / 1000.0;
-}
+typedef struct {
+    double eventFinish, emptyFinish;
+    int is_animated;
+} EventStopTimesResult;
 
 static int _is_move_tag_animated(char *begin, char *end) {
     int params[6];
@@ -201,63 +188,6 @@ static int _is_event_animated(ASS_Event *event) {
     return 0;
 }
 
-static void detect_animated_events() {
-    ASS_Event *cur = track->events;
-    int *animated = is_animated_events;
-    for (int i = 0; i < track->n_events; i++, cur++, animated++) {
-        *animated = _is_event_animated(cur);
-    }
-}
-
-void libassjs_find_event_stop_times(double tm, double *eventFinish, double *emptyFinish, int *is_animated) {
-    if (!track || track->n_events == 0) {
-        *eventFinish = *emptyFinish = -1;
-        return;
-    }
-
-    ASS_Event *cur = track->events;
-    long long now = (long long)(tm * 1000);
-
-    long long minFinish = -1, maxFinish = -1, minStart = -1;
-    int current_animated = 0;
-
-    for (int i = 0; i < track->n_events; i++, cur++) {
-        long long start = cur->Start;
-        long long finish = start + cur->Duration;
-        if (start <= now) {
-            if (finish > now) {
-                if (finish < minFinish || minFinish == -1) {
-                    minFinish = finish;
-                }
-                if (finish > maxFinish) {
-                    maxFinish = finish;
-                }
-                if (!current_animated) current_animated = m_is_event_animated[i];
-            }
-        } else if (start < minStart || minStart == -1) {
-            minStart = start;
-        }
-    }
-    *is_animated = current_animated;
-
-    if (minFinish != -1) {
-        // some event is going on, so we need to re-draw either when it stops
-        // or when some other event starts
-        *eventFinish = ((minFinish < minStart) ? minFinish : minStart) / 1000.0;
-    } else {
-        // there's no current event, so no need to draw anything
-        *eventFinish = -1;
-    }
-
-    if (minFinish == maxFinish && (minStart == -1 || minStart > maxFinish)) {
-        // there's empty space after this event ends
-        *emptyFinish = minStart / 1000.0;
-    } else {
-        // there's no empty space after eventFinish happens
-        *emptyFinish = *eventFinish;
-    }
-}
-
 class SubtitleOctopus {
 public:
     ASS_Library* ass_library;
@@ -319,7 +249,7 @@ public:
             printf("cannot parse animated events\n");
             exit(5);
         }
-        detect_animated_events();
+        detectAnimatedEvents();
     }
 
     void createTrackMem(char *buf, unsigned long bufsize) {
@@ -521,7 +451,84 @@ public:
         return &m_blendResult;
     }
 
+    double findNextEventStart(double tm) {
+        if (!track || track->n_events == 0) return -1;
+
+        ASS_Event *cur = track->events;
+        long long now = (long long)(tm * 1000);
+        long long closest = -1;
+
+        for (int i = 0; i < track->n_events; i++, cur++) {
+            long long start = cur->Start;
+            if (start >= now && (start < closest || closest == -1)) {
+                closest = start;
+            }
+        }
+
+        return closest / 1000.0;
+    }
+
+    EventStopTimesResult findEventStopTimes(double tm) {
+        EventStopTimesResult result;
+        if (!track || track->n_events == 0) {
+            result.eventFinish = result.emptyFinish = -1;
+            return result;
+        }
+
+        ASS_Event *cur = track->events;
+        long long now = (long long)(tm * 1000);
+
+        long long minFinish = -1, maxFinish = -1, minStart = -1;
+        int current_animated = 0;
+
+        for (int i = 0; i < track->n_events; i++, cur++) {
+            long long start = cur->Start;
+            long long finish = start + cur->Duration;
+            if (start <= now) {
+                if (finish > now) {
+                    if (finish < minFinish || minFinish == -1) {
+                        minFinish = finish;
+                    }
+                    if (finish > maxFinish) {
+                        maxFinish = finish;
+                    }
+                    if (!current_animated) current_animated = m_is_event_animated[i];
+                }
+            } else if (start < minStart || minStart == -1) {
+                minStart = start;
+            }
+        }
+        result.is_animated = current_animated;
+
+        if (minFinish != -1) {
+            // some event is going on, so we need to re-draw either when it stops
+            // or when some other event starts
+            result.eventFinish = ((minFinish < minStart) ? minFinish : minStart) / 1000.0;
+        } else {
+            // there's no current event, so no need to draw anything
+            result.eventFinish = -1;
+        }
+
+        if (minFinish == maxFinish && (minStart == -1 || minStart > maxFinish)) {
+            // there's empty space after this event ends
+            result.emptyFinish = minStart / 1000.0;
+        } else {
+            // there's no empty space after eventFinish happens
+            result.emptyFinish = result.eventFinish;
+        }
+
+        return result;
+    }
+
 private:
+    void detectAnimatedEvents() {
+        ASS_Event *cur = track->events;
+        int *animated = m_is_event_animated;
+        for (int i = 0; i < track->n_events; i++, cur++, animated++) {
+            *animated = _is_event_animated(cur);
+        }
+    }
+
     ReusableBuffer m_blend;
     RenderBlendResult m_blendResult;
     int *m_is_event_animated;

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -123,10 +123,10 @@ int _is_event_complex(ASS_Event *event) {
     return 0;
 }
 
-void libassjs_find_event_stop_times(double tm, double *eventFinish, double *emptyFinish) {
+int libassjs_find_event_stop_times(double tm, double *eventFinish, double *emptyFinish) {
     if (!track || track->n_events == 0) {
         *eventFinish = *emptyFinish = -1;
-        return;
+        return 0;
     }
 
     ASS_Event *cur = track->events;
@@ -153,14 +153,6 @@ void libassjs_find_event_stop_times(double tm, double *eventFinish, double *empt
         }
     }
 
-    if (current_animated) {
-        printf("libass: detected animated event, forcing finish times to be +5ms from %f\n", tm);
-        // what plays now is animated, so consider this event border to be
-        // after 5ms from now, so it's properly redrawn afterwards
-        *eventFinish = *emptyFinish = tm + 0.005;
-        return;
-    }
-
     if (minFinish != -1) {
         // some event is going on, so we need to re-draw either when it stops
         // or when some other event starts
@@ -177,6 +169,8 @@ void libassjs_find_event_stop_times(double tm, double *eventFinish, double *empt
         // there's no empty space after eventFinish happens
         *emptyFinish = *eventFinish;
     }
+
+    return current_animated;
 }
 
 class SubtitleOctopus {

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -468,11 +468,11 @@ public:
         return closest / 1000.0;
     }
 
-    EventStopTimesResult findEventStopTimes(double tm) {
-        EventStopTimesResult result;
+    EventStopTimesResult* findEventStopTimes(double tm) {
+        static EventStopTimesResult result;
         if (!track || track->n_events == 0) {
             result.eventFinish = result.emptyFinish = -1;
-            return result;
+            return &result;
         }
 
         ASS_Event *cur = track->events;
@@ -517,7 +517,7 @@ public:
             result.emptyFinish = result.eventFinish;
         }
 
-        return result;
+        return &result;
     }
 
 private:

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -18,53 +18,53 @@
 #endif
 
 int log_level = 3;
-int *is_event_animated;
 
-typedef struct {
+class ReusableBuffer {
+public:
+    ReusableBuffer(): buffer(NULL), size(-1), lessen_counter(0) {}
+    ~ReusableBuffer() {
+        free(buffer);
+    }
+    void clear() {
+        free(buffer);
+        buffer = NULL;
+        size = -1;
+        lessen_counter = 0;
+    }
+    void *take(int new_size, bool keep_content) {
+        if (size >= new_size) {
+            if (size >= 1.3 * new_size) {
+                // big reduction request
+                lessen_counter++;
+            } else {
+                lessen_counter = 0;
+            }
+            if (lessen_counter < 10) {
+                // not reducing the buffer yet
+                return buffer;
+            }
+        }
+
+        void *newbuf;
+        if (keep_content) {
+            newbuf = realloc(buffer, new_size);
+        } else {
+            newbuf = malloc(new_size);
+        }
+        if (!newbuf) return NULL;
+
+        if (!keep_content) free(buffer);
+        buffer = newbuf;
+        size = new_size;
+        lessen_counter = 0;
+        return buffer;
+    }
+
+private:
     void *buffer;
     int size;
     int lessen_counter;
-} buffer_t;
-
-void* buffer_resize(buffer_t *buf, int new_size, int keep_content) {
-    if (buf->size >= new_size) {
-        if (buf->size >= 1.3 * new_size) {
-            // big reduction request
-            buf->lessen_counter++;
-        } else {
-            buf->lessen_counter = 0;
-        }
-        if (buf->lessen_counter < 10) {
-            // not reducing the buffer yet
-            return buf->buffer;
-        }
-    }
-
-    void *newbuf;
-    if (keep_content) {
-        newbuf = realloc(buf->buffer, new_size);
-    } else {
-        newbuf = malloc(new_size);
-    }
-    if (!newbuf) return NULL;
-
-    if (!keep_content) free(buf->buffer);
-    buf->buffer = newbuf;
-    buf->size = new_size;
-    buf->lessen_counter = 0;
-    return buf->buffer;
-}
-
-void buffer_init(buffer_t *buf) {
-    buf->buffer = NULL;
-    buf->size = -1;
-    buf->lessen_counter = 0;
-}
-
-void buffer_free(buffer_t *buf) {
-    free(buf->buffer);
-    buffer_init(buf);
-}
+};
 
 void msg_callback(int level, const char *fmt, va_list va, void *data) {
     if (level > log_level) // 6 for verbose
@@ -232,7 +232,7 @@ void libassjs_find_event_stop_times(double tm, double *eventFinish, double *empt
                 if (finish > maxFinish) {
                     maxFinish = finish;
                 }
-                if (!current_animated) current_animated = is_event_animated[i];
+                if (!current_animated) current_animated = m_is_event_animated[i];
             }
         } else if (start < minStart || minStart == -1) {
             minStart = start;
@@ -300,8 +300,8 @@ public:
         resizeCanvas(frame_w, frame_h);
 
         reloadFonts();
-        buffer_init(&m_blend);
-        is_event_animated = NULL;
+        m_blend.clear();
+        m_is_event_animated = NULL;
     }
 
     /* TRACK */
@@ -313,9 +313,9 @@ public:
             exit(4);
         }
 
-        free(is_event_animated);
-        is_event_animated = (int*)malloc(sizeof(int) * track->n_events);
-        if (is_event_animated == NULL) {
+        free(m_is_event_animated);
+        m_is_event_animated = (int*)malloc(sizeof(int) * track->n_events);
+        if (m_is_event_animated == NULL) {
             printf("cannot parse animated events\n");
             exit(5);
         }
@@ -336,8 +336,8 @@ public:
             ass_free_track(track);
             track = NULL;
         }
-        free(is_event_animated);
-        is_event_animated = NULL;
+        free(m_is_event_animated);
+        m_is_event_animated = NULL;
     }
     /* TRACK */
 
@@ -357,9 +357,9 @@ public:
         ass_free_track(track);
         ass_renderer_done(ass_renderer);
         ass_library_done(ass_library);
-        buffer_free(&m_blend);
-        free(is_event_animated);
-        is_event_animated = NULL;
+        m_blend.clear();
+        free(m_is_event_animated);
+        m_is_event_animated = NULL;
     }
     void reloadLibrary() {
         quitLibrary();
@@ -442,7 +442,7 @@ public:
 
         // make float buffer for blending
         int width = max_x - min_x + 1, height = max_y - min_y + 1;
-        float* buf = (float*)buffer_resize(&m_blend, sizeof(float) * width * height * 4, 0);
+        float* buf = (float*)m_blend.take(sizeof(float) * width * height * 4, 0);
         if (buf == NULL) {
             printf("libass: error: cannot allocate buffer for blending");
             return NULL;
@@ -522,10 +522,13 @@ public:
     }
 
 private:
-    buffer_t m_blend;
+    ReusableBuffer m_blend;
     RenderBlendResult m_blendResult;
+    int *m_is_event_animated;
 };
 
 int main(int argc, char *argv[]) { return 0; }
 
+#ifdef __EMSCRIPTEN__
 #include "./SubOctpInterface.cpp"
+#endif

--- a/src/SubtitleOctopus.idl
+++ b/src/SubtitleOctopus.idl
@@ -165,6 +165,13 @@ interface RenderBlendResult {
     attribute ByteString image;
 };
 
+[NoDelete]
+interface EventStopTimesResult {
+    attribute double eventFinish;
+    attribute double emptyFinish;
+    attribute long is_animated;
+};
+
 interface SubtitleOctopus {
     void SubtitleOctopus();
     attribute ASS_Track track;
@@ -191,4 +198,6 @@ interface SubtitleOctopus {
     void removeAllEvents();
     void setMemoryLimits(long glyph_limit, long bitmap_cache_limit);
     RenderBlendResult renderBlend(double tm, long force);
+    double findNextEventStart(double tm);
+    EventStopTimesResult findEventStopTimes(double tm);
 };

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -205,7 +205,7 @@ self.render = function (force) {
 self.blendRenderTiming = function (timing, force) {
     var startTime = performance.now();
 
-    var renderResult = self.octObj.renderBlend(self.getCurrentTime() + self.delay, force);
+    var renderResult = self.octObj.renderBlend(timing, force);
     var blendTime = renderResult.blend_time;
     var canvases = [], buffers = [];
     if (renderResult.ptr != 0 && (renderResult.changed != 0 || force)) {

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -251,7 +251,7 @@ self.oneshotRender = function (lastRenderedTime, renderNow, iteration) {
     var eventFinish = -1.0, emptyFinish = -1.0, animated = false;
     var rendered = {};
     if (eventStart >= 0) {
-        eventTimes = self.findNextEventStart(eventStart);
+        eventTimes = self.octObj.findEventStopTimes(eventStart);
         eventFinish = eventTimes.eventFinish;
         emptyFinish = eventTimes.emptyFinish;
         animated = eventTimes.is_animated;

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -206,7 +206,7 @@ self.blendRenderTiming = function (timing, force) {
     var startTime = performance.now();
 
     var renderResult = self.octObj.renderBlend(self.getCurrentTime() + self.delay, force);
-    var blendTime = Module.getValue(self.blendTime, 'double');
+    var blendTime = renderResult.blend_time;
     var canvases = [], buffers = [];
     if (renderResult && (renderResult.changed != 0 || force)) {
         // make a copy, as we should free the memory so subsequent calls can utilize it
@@ -247,14 +247,14 @@ self.blendRender = function (force) {
 };
 
 self.oneshotRender = function (lastRenderedTime, renderNow, iteration) {
-    var eventStart = renderNow ? lastRenderedTime : self._find_next_event_start(lastRenderedTime);
+    var eventStart = renderNow ? lastRenderedTime : self.octObj.findNextEventStart(lastRenderedTime);
     var eventFinish = -1.0, emptyFinish = -1.0, animated = false;
     var rendered = {};
     if (eventStart >= 0) {
-        self._find_event_stop_times(eventStart, self.eventFinish, self.emptyFinish, self.isAnimated);
-        eventFinish = Module.getValue(self.eventFinish, 'double');
-        emptyFinish = Module.getValue(self.emptyFinish, 'double');
-        animated = Module.getValue(self.isAnimated, 'i32') != 0;
+        eventTimes = self.findNextEventStart(eventStart);
+        eventFinish = eventTimes.eventFinish;
+        emptyFinish = eventTimes.emptyFinish;
+        animated = eventTimes.is_animated;
 
         rendered = self.blendRenderTiming(eventStart, true);
     }

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -262,6 +262,7 @@ self.oneshotRender = function (lastRenderedTime, renderNow, iteration) {
         target: 'canvas',
         op: 'oneshot-result',
         iteration: iteration,
+        lastRenderedTime: lastRenderedTime,
         eventStart: eventStart,
         eventFinish: eventFinish,
         emptyFinish: emptyFinish,

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -8,6 +8,7 @@ self.nextIsRaf = false;
 self.lastCurrentTimeReceivedAt = Date.now();
 self.targetFps = 30;
 self.libassMemoryLimit = 0; // in MiB
+self.renderOnDemand = false; // determines if only rendering on demand
 
 self.width = 0;
 self.height = 0;
@@ -86,7 +87,9 @@ self.setTrack = function (content) {
     // Tell libass to render the new track
     self.octObj.createTrack("/sub.ass");
     self.ass_track = self.octObj.track;
-    self.getRenderMethod()();
+    if (!self.renderOnDemand) {
+        self.getRenderMethod()();
+    }
 };
 
 /**
@@ -94,7 +97,9 @@ self.setTrack = function (content) {
  */
 self.freeTrack = function () {
     self.octObj.removeTrack();
-    self.getRenderMethod()();
+    if (!self.renderOnDemand) {
+        self.getRenderMethod()();
+    }
 };
 
 /**
@@ -135,10 +140,14 @@ self.setCurrentTime = function (currentTime) {
     self.lastCurrentTimeReceivedAt = Date.now();
     if (!self.rafId) {
         if (self.nextIsRaf) {
-            self.rafId = self.requestAnimationFrame(self.getRenderMethod());
+            if (!self.renderOnDemand) {
+                self.rafId = self.requestAnimationFrame(self.getRenderMethod());
+            }
         }
         else {
-            self.getRenderMethod()();
+            if (!self.renderOnDemand) {
+                self.getRenderMethod()();
+            }
             
             // Give onmessage chance to receive all queued messages
             setTimeout(function () {
@@ -163,7 +172,9 @@ self.setIsPaused = function (isPaused) {
         }
         else {
             self.lastCurrentTimeReceivedAt = Date.now();
-            self.rafId = self.requestAnimationFrame(self.getRenderMethod());
+            if (!self.renderOnDemand) {
+                self.rafId = self.requestAnimationFrame(self.getRenderMethod());
+            }
         }
     }
 };
@@ -191,34 +202,73 @@ self.render = function (force) {
     }
 };
 
-self.blendRender = function (force) {
-    self.rafId = 0;
-    self.renderPending = false;
+self.blendRenderTiming(timing, force) {
     var startTime = performance.now();
 
     var renderResult = self.octObj.renderBlend(self.getCurrentTime() + self.delay, force);
     var blendTime = Module.getValue(self.blendTime, 'double');
+    var canvases = [], buffers = [];
     if (renderResult && (renderResult.changed != 0 || force)) {
         // make a copy, as we should free the memory so subsequent calls can utilize it
         var result = new Uint8Array(HEAPU8.subarray(renderResult.image, renderResult.image + renderResult.dest_width * renderResult.dest_height * 4));
 
-        var canvases = [{w: renderResult.dest_width, h: renderResult.dest_height, x: renderResult.dest_x, y: renderResult.dest_y, buffer: result.buffer}];
-        var buffers = [result.buffer];
+        canvases = [{w: renderResult.dest_width, h: renderResult.dest_height, x: renderResult.dest_x, y: renderResult.dest_y, buffer: result.buffer}];
+        buffers = [result.buffer];
+    }
 
+    return {
+        time: Date.now(),
+        spentTime: performance.now() - startTime,
+        blendTime: blendTime,
+        canvases: canvases,
+        buffers: buffers
+    }
+}
+
+self.blendRender = function (force) {
+    self.rafId = 0;
+    self.renderPending = false;
+
+    var rendered = self.blendRenderTiming(self.getCurrentTime() + self.delay, force);
+    if (rendered.canvases.length > 0) {
         postMessage({
             target: 'canvas',
             op: 'renderCanvas',
-            time: Date.now(),
-            spentTime: performance.now() - startTime,
-            blendTime: blendTime,
-            canvases: canvases
-        }, buffers);
+            time: rendered.time,
+            spentTime: rendered.spentTime,
+            blendTime: rendered.blendTime,
+            canvases: rendered.canvases
+        }, rendered.buffers);
     }
 
     if (!self._isPaused) {
         self.rafId = self.requestAnimationFrame(self.blendRender);
     }
 };
+
+self.oneshotRender = function (lastRenderedTime, renderNow) {
+    var eventStart = renderNow ? lastRenderedTime : self._find_next_event_start(lastRenderedTime);
+    var eventFinish = -1.0, emptyFinish = -1.0;
+    var rendered = {};
+    if (eventStart >= 0) {
+        self._libassjs_find_event_stop_times(eventStart, self.eventFinish, self.emptyFinish);
+        eventFinish = Module.getValue(self.eventFinish, 'double');
+        emptyFinish = Module.getValue(self.emptyFinish, 'double');
+
+        rendered = self.blendRenderTiming(eventStart, true);
+    }
+
+    postMessage({
+        target: 'canvas',
+        op: 'oneshot-result',
+        eventStart: eventStart,
+        eventFinish: eventFinish,
+        emptyFinish: emptyFinish,
+        spentTime: rendered.spentTime || 0,
+        blendTime: rendered.blendTime || 0,
+        canvases: rendered.canvases || []
+    }, rendered.buffers || []);
+}
 
 self.fastRender = function (force) {
     self.rafId = 0;
@@ -496,7 +546,9 @@ function onMessageFromMainEmscriptenThread(message) {
                     Module.canvas.boundingClientRect = message.data.boundingClientRect;
                 }
                 self.resize(message.data.width, message.data.height);
-                self.getRenderMethod()();
+                if (!self.renderOnDemand) {
+                    self.getRenderMethod()();
+                }
             } else throw 'ey?';
             break;
         }
@@ -540,9 +592,13 @@ function onMessageFromMainEmscriptenThread(message) {
             self.targetFps = message.data.targetFps || self.targetFps;
             self.libassMemoryLimit = message.data.libassMemoryLimit || self.libassMemoryLimit;
             self.libassGlyphLimit = message.data.libassGlyphLimit || 0;
+            self.renderOnDemand = message.data.renderOnDemand || false;
             removeRunDependency('worker-init');
             break;
         }
+        case 'oneshot':
+            self.oneshotRender(message.data.lastRendered, message.data.renderNow || false);
+            break;
         case 'destroy':
             self.octObj.quitLibrary();
             break;

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -22,11 +22,11 @@ self.fontId = 0;
  */
 self.writeFontToFS = function(font) {
     font = font.trim().toLowerCase();
-    
+
     if (font.startsWith("@")) {
         font = font.substr(1);
     }
-    
+
     if (self.fontMap_.hasOwnProperty(font)) return;
 
     self.fontMap_[font] = true;
@@ -34,7 +34,7 @@ self.writeFontToFS = function(font) {
     if (!self.availableFonts.hasOwnProperty(font)) return;
     var content = readBinary(self.availableFonts[font]);
 
-    Module["FS"].writeFile('/fonts/font' + (self.fontId++) + '-' + self.availableFonts[font].split('/').pop(), content, { 
+    Module["FS"].writeFile('/fonts/font' + (self.fontId++) + '-' + self.availableFonts[font].split('/').pop(), content, {
         encoding: 'binary'
     });
 };
@@ -55,7 +55,7 @@ self.writeAvailableFontsToFS = function(content) {
             }
         }
     }
-    
+
     var regex = /\\fn([^\\}]*?)[\\}]/g;
     var matches;
     while (matches = regex.exec(self.subContent)) {
@@ -148,7 +148,7 @@ self.setCurrentTime = function (currentTime) {
             if (!self.renderOnDemand) {
                 self.getRenderMethod()();
             }
-            
+
             // Give onmessage chance to receive all queued messages
             setTimeout(function () {
                 self.nextIsRaf = false;
@@ -202,7 +202,7 @@ self.render = function (force) {
     }
 };
 
-self.blendRenderTiming(timing, force) {
+self.blendRenderTiming = function (timing, force) {
     var startTime = performance.now();
 
     var renderResult = self.octObj.renderBlend(self.getCurrentTime() + self.delay, force);
@@ -246,7 +246,7 @@ self.blendRender = function (force) {
     }
 };
 
-self.oneshotRender = function (lastRenderedTime, renderNow) {
+self.oneshotRender = function (lastRenderedTime, renderNow, iteration) {
     var eventStart = renderNow ? lastRenderedTime : self._find_next_event_start(lastRenderedTime);
     var eventFinish = -1.0, emptyFinish = -1.0;
     var rendered = {};
@@ -261,6 +261,7 @@ self.oneshotRender = function (lastRenderedTime, renderNow) {
     postMessage({
         target: 'canvas',
         op: 'oneshot-result',
+        iteration: iteration,
         eventStart: eventStart,
         eventFinish: eventFinish,
         emptyFinish: emptyFinish,
@@ -596,8 +597,10 @@ function onMessageFromMainEmscriptenThread(message) {
             removeRunDependency('worker-init');
             break;
         }
-        case 'oneshot':
-            self.oneshotRender(message.data.lastRendered, message.data.renderNow || false);
+        case 'oneshot-render':
+            self.oneshotRender(message.data.lastRendered,
+                    message.data.renderNow || false,
+                    message.data.iteration);
             break;
         case 'destroy':
             self.octObj.quitLibrary();

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -251,9 +251,10 @@ self.oneshotRender = function (lastRenderedTime, renderNow, iteration) {
     var eventFinish = -1.0, emptyFinish = -1.0, animated = false;
     var rendered = {};
     if (eventStart >= 0) {
-        animated = self._find_event_stop_times(eventStart, self.eventFinish, self.emptyFinish) != 0;
+        self._find_event_stop_times(eventStart, self.eventFinish, self.emptyFinish, self.isAnimated);
         eventFinish = Module.getValue(self.eventFinish, 'double');
         emptyFinish = Module.getValue(self.emptyFinish, 'double');
+        animated = Module.getValue(self.isAnimated, 'i32') != 0;
 
         rendered = self.blendRenderTiming(eventStart, true);
     }

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -248,10 +248,10 @@ self.blendRender = function (force) {
 
 self.oneshotRender = function (lastRenderedTime, renderNow, iteration) {
     var eventStart = renderNow ? lastRenderedTime : self._find_next_event_start(lastRenderedTime);
-    var eventFinish = -1.0, emptyFinish = -1.0;
+    var eventFinish = -1.0, emptyFinish = -1.0, animated = false;
     var rendered = {};
     if (eventStart >= 0) {
-        self._libassjs_find_event_stop_times(eventStart, self.eventFinish, self.emptyFinish);
+        animated = self._find_event_stop_times(eventStart, self.eventFinish, self.emptyFinish) != 0;
         eventFinish = Module.getValue(self.eventFinish, 'double');
         emptyFinish = Module.getValue(self.emptyFinish, 'double');
 
@@ -266,6 +266,7 @@ self.oneshotRender = function (lastRenderedTime, renderNow, iteration) {
         eventStart: eventStart,
         eventFinish: eventFinish,
         emptyFinish: emptyFinish,
+        animated: animated,
         spentTime: rendered.spentTime || 0,
         blendTime: rendered.blendTime || 0,
         canvases: rendered.canvases || []

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -208,7 +208,7 @@ self.blendRenderTiming = function (timing, force) {
     var renderResult = self.octObj.renderBlend(self.getCurrentTime() + self.delay, force);
     var blendTime = renderResult.blend_time;
     var canvases = [], buffers = [];
-    if (renderResult && (renderResult.changed != 0 || force)) {
+    if (renderResult.ptr != 0 && (renderResult.changed != 0 || force)) {
         // make a copy, as we should free the memory so subsequent calls can utilize it
         var result = new Uint8Array(HEAPU8.subarray(renderResult.image, renderResult.image + renderResult.dest_width * renderResult.dest_height * 4));
 

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -92,8 +92,8 @@ Module["preRun"].push(function () {
 Module['onRuntimeInitialized'] = function () {
     self.octObj = new Module.SubtitleOctopus();
 
-    self._find_next_event_start = Module['cwrap']('_libassjs_find_next_event_start', 'number', ['number']);
-    self._find_event_stop_times = Module['cwrap']('_libassjs_find_event_stop_times', null, ['number', 'number', 'number']);
+    self._find_next_event_start = Module['cwrap']('libassjs_find_next_event_start', 'number', ['number']);
+    self._find_event_stop_times = Module['cwrap']('libassjs_find_event_stop_times', null, ['number', 'number', 'number']);
 
     self.changed = Module._malloc(4);
     self.blendTime = Module._malloc(8);

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -92,19 +92,7 @@ Module["preRun"].push(function () {
 Module['onRuntimeInitialized'] = function () {
     self.octObj = new Module.SubtitleOctopus();
 
-    self._find_next_event_start = Module['cwrap']('libassjs_find_next_event_start', 'number', ['number']);
-    self._find_event_stop_times = Module['cwrap']('libassjs_find_event_stop_times', null, ['number', 'number', 'number', 'number']);
-
     self.changed = Module._malloc(4);
-    self.blendTime = Module._malloc(8);
-    self.blendX = Module._malloc(4);
-    self.blendY = Module._malloc(4);
-    self.blendW = Module._malloc(4);
-    self.blendH = Module._malloc(4);
-
-    self.eventFinish = Module._malloc(8);
-    self.emptyFinish = Module._malloc(8);
-    self.isAnimated = Module._malloc(4);
 
     self.octObj.initLibrary(screen.width, screen.height);
     self.octObj.createTrack("/sub.ass");

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -92,12 +92,18 @@ Module["preRun"].push(function () {
 Module['onRuntimeInitialized'] = function () {
     self.octObj = new Module.SubtitleOctopus();
 
+    self._find_next_event_start = Module['cwrap']('_libassjs_find_next_event_start', 'number', ['number']);
+    self._find_event_stop_times = Module['cwrap']('_libassjs_find_event_stop_times', null, ['number', 'number', 'number']);
+
     self.changed = Module._malloc(4);
     self.blendTime = Module._malloc(8);
     self.blendX = Module._malloc(4);
     self.blendY = Module._malloc(4);
     self.blendW = Module._malloc(4);
     self.blendH = Module._malloc(4);
+
+    self.eventFinish = Module._malloc(8);
+    self.emptyFinish = Module._malloc(8);
 
     self.octObj.initLibrary(screen.width, screen.height);
     self.octObj.createTrack("/sub.ass");

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -93,7 +93,7 @@ Module['onRuntimeInitialized'] = function () {
     self.octObj = new Module.SubtitleOctopus();
 
     self._find_next_event_start = Module['cwrap']('libassjs_find_next_event_start', 'number', ['number']);
-    self._find_event_stop_times = Module['cwrap']('libassjs_find_event_stop_times', null, ['number', 'number', 'number']);
+    self._find_event_stop_times = Module['cwrap']('libassjs_find_event_stop_times', null, ['number', 'number', 'number', 'number']);
 
     self.changed = Module._malloc(4);
     self.blendTime = Module._malloc(8);
@@ -104,6 +104,7 @@ Module['onRuntimeInitialized'] = function () {
 
     self.eventFinish = Module._malloc(8);
     self.emptyFinish = Module._malloc(8);
+    self.isAnimated = Module._malloc(4);
 
     self.octObj.initLibrary(screen.width, screen.height);
     self.octObj.createTrack("/sub.ass");

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -572,7 +572,7 @@ var SubtitlesOctopus = function (options) {
                         if ((data.emptyFinish > 0 && data.emptyFinish - data.eventStart < 1.0 / self.targetFps) || data.animated) {
                             var newFinish = data.eventStart + 1.0 / self.targetFps;
                             data.emptyFinish = newFinish;
-                            data.eventFinish = (data.eventFinish > newFinish) ? newFinish : data.eventFinish;
+                            data.eventFinish = newFinish;
                         }
                         self.renderedItems.push({
                             eventStart: data.eventStart,

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -16,7 +16,7 @@ var SubtitlesOctopus = function (options) {
     self.renderMode = options.renderMode || (options.lossyRender ? 'fast' : (options.blendRender ? 'blend' : 'normal'));
     self.libassMemoryLimit = options.libassMemoryLimit || 0; // set libass bitmap cache memory limit in MiB (approximate)
     self.libassGlyphLimit = options.libassGlyphLimit || 0; // set libass glyph cache memory limit in MiB (approximate)
-    self.targetFps = options.targetFps || undefined;
+    self.targetFps = options.targetFps || 30;
     self.renderAhead = options.renderAhead || 0; // how many MiB to render ahead and store; 0 to disable (approximate)
     self.isOurCanvas = false; // (internal) we created canvas and manage it
     self.video = options.video; // HTML video element (optional if canvas specified)
@@ -570,11 +570,9 @@ var SubtitlesOctopus = function (options) {
                             size += item.buffer.byteLength;
                         }
                         if ((data.emptyFinish > 0 && data.emptyFinish - data.eventStart < 1.0 / self.targetFps) || data.animated) {
-                            newFinish = data.eventStart + 1.0 / self.targetFps;
-                            if (newFinish < data.emptyFinish) {
-                                data.emptyFinish = newFinish;
-                                data.eventFinish = (data.eventFinish > newFinish) ? newFinish : data.eventFinish;
-                            }
+                            var newFinish = data.eventStart + 1.0 / self.targetFps;
+                            data.emptyFinish = newFinish;
+                            data.eventFinish = (data.eventFinish > newFinish) ? newFinish : data.eventFinish;
                         }
                         self.renderedItems.push({
                             eventStart: data.eventStart,

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -197,6 +197,9 @@ var SubtitlesOctopus = function (options) {
             self.video.addEventListener("seeked", function () {
                 self.video.addEventListener("timeupdate", timeupdate, false);
                 self.setCurrentTime(video.currentTime + self.timeOffset);
+                if (self.renderAhead > 0) {
+                    _cleanPastRendered(video.currentTime + self.timeOffset, true);
+                }
             }, false);
             self.video.addEventListener("ratechange", function () {
                 self.setRate(video.playbackRate);
@@ -254,14 +257,37 @@ var SubtitlesOctopus = function (options) {
     self.setSubUrl = function (subUrl) {
         self.subUrl = subUrl;
     };
-
-    function _cleanPastRendered(currentTime) {
+    
+    function _cleanPastRendered(currentTime, seekClean) {
         var retainedItems = [];
         for (var i = 0, len = self.renderedItems.length; i < len; i++) {
             var item = self.renderedItems[i];
             if (item.emptyFinish < 0 || item.emptyFinish >= currentTime) {
                 // item is not yet finished, retain it
                 retainedItems.push(item);
+            }
+        }
+        if (seekClean && retainedItems.length > 0) {
+            // order items by event start time
+            retainedItems.sort(function (a, b) {
+                return a.eventStart - b.eventStart;
+            });
+            if (currentTime < retainedItems[0].eventStart) {
+                if (retainedItems[0].eventStart - currentTime > 60) {
+                    console.info("seeked back too far, cleaning prerender buffer");
+                    retainedItems = [];
+                } else {
+                    console.info("seeked backwards, need to free up some buffer");
+                    var size = 0, limit = self.renderAhead * 0.3 /* try to take no more than 1/3 of buffer */;
+                    var retain = [];
+                    for (var i = 0, len = retainedItems.length; i < len; i++) {
+                        var item = retainedItems[i];
+                        size += item.size;
+                        if (size >= limit) break;
+                        retain.push(item);
+                    }
+                    retainedItems = retain;
+                }
             }
         }
         var removed = retainedItems.length != self.renderedItems.length;
@@ -355,13 +381,13 @@ var SubtitlesOctopus = function (options) {
             }
         }
 
-        if (_cleanPastRendered(currentTime) && finishTime >= 0) {
-            console.debug('some prerendered frame retired, requesting new');
-            if (eventShown) {
-                tryRequestOneshot(finishTime);
-            } else {
+        if (!eventShown) {
+            if (Math.abs(self.oneshotState.requestNextTimestamp - currentTime) > 0.1) {
                 tryRequestOneshot(currentTime, true);
             }
+        } else if (_cleanPastRendered(currentTime) && finishTime >= 0) {
+            console.debug('some prerendered frame retired, requesting new');
+            tryRequestOneshot(finishTime);
         }
     }
 
@@ -508,6 +534,10 @@ var SubtitlesOctopus = function (options) {
                                 data.eventStart + ', empty=' + data.emptyFinish +
                                 '), render: ' + Math.round(data.spentTime) + ' ms');
                         self.oneshotState.renderRequested = false;
+                        if (data.lastRenderedTime == self.oneshotState.requestNextTimestamp) {
+                            self.oneshotState.requestNextTimestamp = -1;
+                        }
+
                         var items = [];
                         var size = 0;
                         for (var i = 0, len = data.canvases.length; i < len; i++) {
@@ -538,7 +568,6 @@ var SubtitlesOctopus = function (options) {
                         if (self.oneshotState.requestNextTimestamp >= 0) {
                             console.debug("requesting out of order event at " + self.oneshotState.requestNextTimestamp);
                             tryRequestOneshot(self.oneshotState.requestNextTimestamp);
-                            self.oneshotState.requestNextTimestamp = -1;
                         } else if (data.eventStart < 0) {
                             console.info('oneshot received "end of frames" event');
                         } else if (data.emptyFinish >= 0) {

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -13,10 +13,11 @@ var SubtitlesOctopus = function (options) {
 
     var self = this;
     self.canvas = options.canvas; // HTML canvas element (optional if video specified)
-    self.renderMode = options.lossyRender ? 'fast' : (options.blendRender ? 'blend' : 'normal');
+    self.renderMode = options.renderMode || (options.lossyRender ? 'fast' : (options.blendRender ? 'blend' : 'normal'));
     self.libassMemoryLimit = options.libassMemoryLimit || 0;
     self.libassGlyphLimit = options.libassGlyphLimit || 0;
     self.targetFps = options.targetFps || undefined;
+    self.renderAhead = options.renderAhead || 0; // how many frames to render ahead and store; 0 to disable
     self.isOurCanvas = false; // (internal) we created canvas and manage it
     self.video = options.video; // HTML video element (optional if canvas specified)
     self.canvasParent = null; // (internal) HTML canvas parent element
@@ -110,7 +111,8 @@ var SubtitlesOctopus = function (options) {
             debug: self.debug,
             targetFps: self.targetFps,
             libassMemoryLimit: self.libassMemoryLimit,
-            libassGlyphLimit: self.libassGlyphLimit
+            libassGlyphLimit: self.libassGlyphLimit,
+            renderOnDemand: renderAhead > 0
         });
     };
 

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -174,7 +174,6 @@ var SubtitlesOctopus = function (options) {
     self.setVideo = function (video) {
         self.video = video;
         if (self.video) {
-            // hack, for testing
             if (self.renderAhead > 0) {
                 window.requestAnimationFrame(oneshotRender);
                 tryRequestOneshot();
@@ -268,6 +267,8 @@ var SubtitlesOctopus = function (options) {
     }
 
     function tryRequestOneshot(currentTime) {
+        if (!self.renderAhead || self.renderAhead <= 0) return;
+
         if (typeof currentTime === 'undefined') {
             if (!self.video) return;
             currentTime = self.video.currentTime + self.timeOffset;
@@ -590,6 +591,7 @@ var SubtitlesOctopus = function (options) {
                 width: self.canvas.width,
                 height: self.canvas.height
             });
+            resetRenderAheadCache();
         }
     };
 
@@ -625,6 +627,7 @@ var SubtitlesOctopus = function (options) {
             target: 'set-track-by-url',
             url: url
         });
+        resetRenderAheadCache();
     };
 
     self.setTrack = function (content) {
@@ -632,12 +635,14 @@ var SubtitlesOctopus = function (options) {
             target: 'set-track',
             content: content
         });
+        resetRenderAheadCache();
     };
 
     self.freeTrack = function (content) {
         self.worker.postMessage({
             target: 'free-track'
         });
+        resetRenderAheadCache();
     };
 
 

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -176,11 +176,6 @@ var SubtitlesOctopus = function (options) {
     self.setVideo = function (video) {
         self.video = video;
         if (self.video) {
-            if (self.renderAhead > 0) {
-                console.debug('starting oneshot render because new video detected');
-                window.requestAnimationFrame(oneshotRender);
-                tryRequestOneshot();
-            }
             var timeupdate = function () {
                 self.setCurrentTime(video.currentTime + self.timeOffset);
             }
@@ -267,11 +262,10 @@ var SubtitlesOctopus = function (options) {
                 retainedItems.push(item);
             }
         }
+
         if (seekClean && retainedItems.length > 0) {
-            // order items by event start time
-            retainedItems.sort(function (a, b) {
-                return a.eventStart - b.eventStart;
-            });
+            // items are ordered by event start time when we push to self.renderedItems,
+            // so first item is the earliest
             if (currentTime < retainedItems[0].eventStart) {
                 if (retainedItems[0].eventStart - currentTime > 60) {
                     console.info("seeked back too far, cleaning prerender buffer");
@@ -290,14 +284,15 @@ var SubtitlesOctopus = function (options) {
                 }
             }
         }
-        var removed = retainedItems.length != self.renderedItems.length;
+
+        var removed = retainedItems.length < self.renderedItems;
         self.renderedItems = retainedItems;
         return removed;
     }
 
-    function tryRequestOneshot(currentTime, postIfBusy) {
+    function tryRequestOneshot(currentTime, renderNow) {
         if (!self.renderAhead || self.renderAhead <= 0) return;
-        if (self.oneshotState.renderRequested && !postIfBusy) return;
+        if (self.oneshotState.renderRequested && !renderNow) return;
 
         if (typeof currentTime === 'undefined') {
             if (!self.video) return;
@@ -322,14 +317,14 @@ var SubtitlesOctopus = function (options) {
         }
 
         if (size <= self.renderAhead) {
-            lastRendered = currentTime - 0.001;
+            lastRendered = currentTime - (renderNow ? 0 : 0.001);
             console.info('requesting new frame because current prerender size is less than limit (start=' + lastRendered + ')');
             if (!self.oneshotState.renderRequested) {
                 self.oneshotState.renderRequested = true;
                 self.worker.postMessage({
                     target: 'oneshot-render',
                     lastRendered: lastRendered,
-                    renderNow: false,
+                    renderNow: renderNow,
                     iteration: self.oneshotState.iteration
                 });
             } else {
@@ -369,35 +364,47 @@ var SubtitlesOctopus = function (options) {
         if (!self.video) return;
 
         var currentTime = self.video.currentTime + self.timeOffset;
-        var finishTime = -1, eventShown = false;
+        var finishTime = -1, eventShown = false, animated = false;
         for (var i = 0, len = self.renderedItems.length; i < len; i++) {
             var item = self.renderedItems[i];
             if (!eventShown && item.eventStart <= currentTime && (item.emptyFinish < 0 || item.emptyFinish >= currentTime)) {
                 _renderSubtitleEvent(item, currentTime);
                 eventShown = true;
-            }
-            if (item.emptyFinish > finishTime) {
                 finishTime = item.emptyFinish;
+            } else if (finishTime >= 0) {
+                // we've already found a known event, now find
+                // the farthest point of consequent events
+                // NOTE: self.renderedItems may have gaps due to seeking
+                if (item.eventStart - finishTime < 0.01) {
+                    finishTime = item.emptyFinish;
+                    animated = item.animated;
+                } else {
+                    break;
+                }
             }
         }
 
         if (!eventShown) {
-            if (Math.abs(self.oneshotState.requestNextTimestamp - currentTime) > 0.1) {
+            if (Math.abs(self.oneshotState.requestNextTimestamp - currentTime) > 0.01) {
                 tryRequestOneshot(currentTime, true);
             }
         } else if (_cleanPastRendered(currentTime) && finishTime >= 0) {
             console.debug('some prerendered frame retired, requesting new');
-            tryRequestOneshot(finishTime);
+            tryRequestOneshot(finishTime, animated);
         }
     }
 
     function resetRenderAheadCache() {
-        console.debug('resetting prerender cache');
-        self.renderedItems = [];
-        self.oneshotState.eventStart = null;
-        self.oneshotState.iteration++;
-        self.oneshotState.renderRequested = false;
-        tryRequestOneshot();
+        if (self.renderAhead > 0) {
+            console.debug('resetting prerender cache');
+            self.renderedItems = [];
+            self.oneshotState.eventStart = null;
+            self.oneshotState.iteration++;
+            self.oneshotState.renderRequested = false;
+
+            window.requestAnimationFrame(oneshotRender);
+            tryRequestOneshot(undefined, true);
+        }
     }
 
     self.renderFrameData = null;
@@ -534,8 +541,21 @@ var SubtitlesOctopus = function (options) {
                                 data.eventStart + ', empty=' + data.emptyFinish +
                                 '), render: ' + Math.round(data.spentTime) + ' ms');
                         self.oneshotState.renderRequested = false;
-                        if (data.lastRenderedTime == self.oneshotState.requestNextTimestamp) {
+                        if (Math.abs(data.lastRenderedTime - self.oneshotState.requestNextTimestamp) < 0.01) {
                             self.oneshotState.requestNextTimestamp = -1;
+                        }
+                        if (data.eventStart - data.lastRenderedTime > 0.01) {
+                            // generate bogus empty element, so all timeline is covered anyway
+                            self.renderedItems.push({
+                                eventStart: data.lastRenderedTime,
+                                eventFinish: data.lastRenderedTime - 0.001,
+                                emptyFinish: data.eventStart,
+                                spentTime: 0,
+                                blendTime: 0,
+                                items: [],
+                                animated: false,
+                                size: 0
+                            });
                         }
 
                         var items = [];
@@ -551,9 +571,12 @@ var SubtitlesOctopus = function (options) {
                             });
                             size += item.buffer.byteLength;
                         }
-                        if (data.emptyFinish > 0 && data.emptyFinish - data.eventStart < 1.0 / self.targetFps) {
-                            data.emptyFinish = data.eventStart + 1.0 / self.targetFps;
-                            data.eventFinish = data.emptyFinish;
+                        if ((data.emptyFinish > 0 && data.emptyFinish - data.eventStart < 1.0 / self.targetFps) || data.animated) {
+                            newFinish = data.eventStart + 1.0 / self.targetFps;
+                            if (newFinish < data.emptyFinish) {
+                                data.emptyFinish = newFinish;
+                                data.eventFinish = (data.eventFinish > newFinish) ? newFinish : data.eventFinish;
+                            }
                         }
                         self.renderedItems.push({
                             eventStart: data.eventStart,
@@ -562,17 +585,22 @@ var SubtitlesOctopus = function (options) {
                             spentTime: data.spentTime,
                             blendTime: data.blendTime,
                             items: items,
+                            animated: data.animated,
                             size: size
+                        });
+                        
+                        self.renderedItems.sort(function (a, b) {
+                            return a.eventStart - b.eventStart;
                         });
 
                         if (self.oneshotState.requestNextTimestamp >= 0) {
                             console.debug("requesting out of order event at " + self.oneshotState.requestNextTimestamp);
-                            tryRequestOneshot(self.oneshotState.requestNextTimestamp);
+                            tryRequestOneshot(self.oneshotState.requestNextTimestamp, true);
                         } else if (data.eventStart < 0) {
                             console.info('oneshot received "end of frames" event');
                         } else if (data.emptyFinish >= 0) {
                             console.debug("there's some more event to render, try requesting next event");
-                            tryRequestOneshot(data.emptyFinish);
+                            tryRequestOneshot(data.emptyFinish, data.animated);
                         } else {
                             console.info('there are no more events to prerender');
                         }


### PR DESCRIPTION
This also should help with complex animated subs if those are rare, and overall reduce the strain on rendering device, as static lines of text are rendered only once, not on each frame being shown.

I've also exposed the option to control the (approximate) size of pre-rendered items to not overburden low-RAM devices.