### PR TITLE
Add "lite render" mode when all animations are disabled

### DIFF
--- a/src/SubOctpInterface.cpp
+++ b/src/SubOctpInterface.cpp
@@ -174,6 +174,14 @@ void EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_setLogLevel_1(Subtitle
   self->setLogLevel(level);
 }
 
+void EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_setDropAnimations_1(SubtitleOctopus* self, int value) {
+  self->setDropAnimations(value);
+}
+
+int EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_getDropAnimations_0(SubtitleOctopus* self) {
+  return self->getDropAnimations();
+}
+
 void EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_initLibrary_2(SubtitleOctopus* self, int frame_w, int frame_h) {
   self->initLibrary(frame_w, frame_h);
 }
@@ -260,6 +268,10 @@ double EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_findNextEventStart_1
 
 EventStopTimesResult* EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_findEventStopTimes_1(SubtitleOctopus* self, double tm) {
   return self->findEventStopTimes(tm);
+}
+
+void EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_rescanAllAnimations_0(SubtitleOctopus* self) {
+  self->rescanAllAnimations();
 }
 
 ASS_Track* EMSCRIPTEN_KEEPALIVE emscripten_bind_SubtitleOctopus_get_track_0(SubtitleOctopus* self) {

--- a/src/SubOctpInterface.js
+++ b/src/SubOctpInterface.js
@@ -420,6 +420,17 @@ SubtitleOctopus.prototype['setLogLevel'] = SubtitleOctopus.prototype.setLogLevel
   _emscripten_bind_SubtitleOctopus_setLogLevel_1(self, level);
 };;
 
+SubtitleOctopus.prototype['setDropAnimations'] = SubtitleOctopus.prototype.setDropAnimations = /** @suppress {undefinedVars, duplicate} */function(value) {
+  var self = this.ptr;
+  if (value && typeof value === 'object') value = value.ptr;
+  _emscripten_bind_SubtitleOctopus_setDropAnimations_1(self, value);
+};;
+
+SubtitleOctopus.prototype['getDropAnimations'] = SubtitleOctopus.prototype.getDropAnimations = /** @suppress {undefinedVars, duplicate} */function() {
+  var self = this.ptr;
+  return _emscripten_bind_SubtitleOctopus_getDropAnimations_0(self);
+};;
+
 SubtitleOctopus.prototype['initLibrary'] = SubtitleOctopus.prototype.initLibrary = /** @suppress {undefinedVars, duplicate} */function(frame_w, frame_h) {
   var self = this.ptr;
   if (frame_w && typeof frame_w === 'object') frame_w = frame_w.ptr;
@@ -556,6 +567,11 @@ SubtitleOctopus.prototype['findEventStopTimes'] = SubtitleOctopus.prototype.find
   var self = this.ptr;
   if (tm && typeof tm === 'object') tm = tm.ptr;
   return wrapPointer(_emscripten_bind_SubtitleOctopus_findEventStopTimes_1(self, tm), EventStopTimesResult);
+};;
+
+SubtitleOctopus.prototype['rescanAllAnimations'] = SubtitleOctopus.prototype.rescanAllAnimations = /** @suppress {undefinedVars, duplicate} */function() {
+  var self = this.ptr;
+  _emscripten_bind_SubtitleOctopus_rescanAllAnimations_0(self);
 };;
 
   SubtitleOctopus.prototype['get_track'] = SubtitleOctopus.prototype.get_track = /** @suppress {undefinedVars, duplicate} */function() {

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -480,7 +480,13 @@ public:
 
         for (int i = 0; i < track->n_events; i++, cur++) {
             long long start = cur->Start;
-            if (start >= now && (start < closest || closest == -1)) {
+            if (start < now) {
+                if (start + cur->Duration >= now) {
+                    // there's currently an event being displayed, we should render it
+                    closest = now;
+                    break;
+                }
+            } else if (start < closest || closest == -1) {
                 closest = start;
             }
         }

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -199,20 +199,20 @@ public:
 
     int status;
 
-    SubtitleOctopus(): status(0), ass_library(NULL), ass_renderer(NULL), track(NULL), canvas_w(0), canvas_h(0), m_is_event_animated(NULL), m_drop_animations(false) {
+    SubtitleOctopus(): ass_library(NULL), ass_renderer(NULL), track(NULL), canvas_w(0), canvas_h(0), status(0), m_is_event_animated(NULL), m_drop_animations(false) {
     }
 
     void setLogLevel(int level) {
         log_level = level;
     }
 
-    void setDropAnimations(bool value) {
-        bool rescan = m_drop_animations != value && track != NULL;
-        m_drop_animations = value;
+    void setDropAnimations(int value) {
+        bool rescan = m_drop_animations != bool(value) && track != NULL;
+        m_drop_animations = bool(value);
         if (rescan) rescanAllAnimations();
     }
 
-    bool getDropAnimations() const {
+    int getDropAnimations() const {
         return m_drop_animations;
     }
 

--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -199,17 +199,21 @@ public:
 
     int status;
 
-    SubtitleOctopus() {
-        status = 0;
-        ass_library = NULL;
-        ass_renderer = NULL;
-        track = NULL;
-        canvas_w = 0;
-        canvas_h = 0;
+    SubtitleOctopus(): status(0), ass_library(NULL), ass_renderer(NULL), track(NULL), canvas_w(0), canvas_h(0), m_is_event_animated(NULL), m_drop_animations(false) {
     }
 
     void setLogLevel(int level) {
         log_level = level;
+    }
+
+    void setDropAnimations(bool value) {
+        bool rescan = m_drop_animations != value && track != NULL;
+        m_drop_animations = value;
+        if (rescan) rescanAllAnimations();
+    }
+
+    bool getDropAnimations() const {
+        return m_drop_animations;
     }
 
     void initLibrary(int frame_w, int frame_h) {
@@ -242,14 +246,7 @@ public:
             printf("Failed to start a track\n");
             exit(4);
         }
-
-        free(m_is_event_animated);
-        m_is_event_animated = (int*)malloc(sizeof(int) * track->n_events);
-        if (m_is_event_animated == NULL) {
-            printf("cannot parse animated events\n");
-            exit(5);
-        }
-        detectAnimatedEvents();
+        rescanAllAnimations();
     }
 
     void createTrackMem(char *buf, unsigned long bufsize) {
@@ -259,6 +256,7 @@ public:
             printf("Failed to start a track\n");
             exit(4);
         }
+        rescanAllAnimations();
     }
 
     void removeTrack() {
@@ -277,6 +275,7 @@ public:
         canvas_h = frame_h;
         canvas_w = frame_w;
     }
+
     ASS_Image* renderImage(double time, int* changed) {
         ASS_Image *img = ass_render_frame(ass_renderer, track, (int) (time * 1000), changed);
         return img;
@@ -291,6 +290,7 @@ public:
         free(m_is_event_animated);
         m_is_event_animated = NULL;
     }
+
     void reloadLibrary() {
         quitLibrary();
 
@@ -305,23 +305,27 @@ public:
         ass_set_margins(ass_renderer, top, bottom, left, right);
     }
 
-    int getEventCount() {
+    int getEventCount() const {
         return track->n_events;
     }
 
     int allocEvent() {
+        free(m_is_event_animated);
+        m_is_event_animated = NULL;
         return ass_alloc_event(track);
     }
 
     void removeEvent(int eid) {
+        free(m_is_event_animated);
+        m_is_event_animated = NULL;
         ass_free_event(track, eid);
     }
 
-    int getStyleCount() {
+    int getStyleCount() const {
         return track->n_styles;
     }
 
-    int getStyleByName(const char* name) {
+    int getStyleByName(const char* name) const {
         for (int n = 0; n < track->n_styles; n++) {
             if (track->styles[n].Name && strcmp(track->styles[n].Name, name) == 0)
                 return n;
@@ -338,6 +342,8 @@ public:
     }
 
     void removeAllEvents() {
+        free(m_is_event_animated);
+        m_is_event_animated = NULL;
         ass_flush_events(track);
     }
 
@@ -451,7 +457,7 @@ public:
         return &m_blendResult;
     }
 
-    double findNextEventStart(double tm) {
+    double findNextEventStart(double tm) const {
         if (!track || track->n_events == 0) return -1;
 
         ASS_Event *cur = track->events;
@@ -468,7 +474,7 @@ public:
         return closest / 1000.0;
     }
 
-    EventStopTimesResult* findEventStopTimes(double tm) {
+    EventStopTimesResult* findEventStopTimes(double tm) const {
         static EventStopTimesResult result;
         if (!track || track->n_events == 0) {
             result.eventFinish = result.emptyFinish = -1;
@@ -492,7 +498,7 @@ public:
                     if (finish > maxFinish) {
                         maxFinish = finish;
                     }
-                    if (!current_animated) current_animated = m_is_event_animated[i];
+                    if (!current_animated && m_is_event_animated) current_animated = m_is_event_animated[i];
                 }
             } else if (start < minStart || minStart == -1) {
                 minStart = start;
@@ -520,8 +526,14 @@ public:
         return &result;
     }
 
-private:
-    void detectAnimatedEvents() {
+    void rescanAllAnimations() {
+        free(m_is_event_animated);
+        m_is_event_animated = (int*)malloc(sizeof(int) * track->n_events);
+        if (m_is_event_animated == NULL) {
+            printf("cannot parse animated events\n");
+            exit(5);
+        }
+
         ASS_Event *cur = track->events;
         int *animated = m_is_event_animated;
         for (int i = 0; i < track->n_events; i++, cur++, animated++) {
@@ -529,9 +541,11 @@ private:
         }
     }
 
+private:
     ReusableBuffer m_blend;
     RenderBlendResult m_blendResult;
     int *m_is_event_animated;
+    bool m_drop_animations;
 };
 
 int main(int argc, char *argv[]) { return 0; }

--- a/src/SubtitleOctopus.idl
+++ b/src/SubtitleOctopus.idl
@@ -178,8 +178,8 @@ interface SubtitleOctopus {
     attribute ASS_Renderer ass_renderer;
     attribute ASS_Library ass_library;
     void setLogLevel(long level);
-    void setDropAnimations(bool value);
-    bool getDropAnimations();
+    void setDropAnimations(long value);
+    long getDropAnimations();
     void initLibrary(long frame_w, long frame_h);
     void createTrack(DOMString subfile);
     void createTrackMem(DOMString buf, unsigned long bufsize);

--- a/src/SubtitleOctopus.idl
+++ b/src/SubtitleOctopus.idl
@@ -178,6 +178,8 @@ interface SubtitleOctopus {
     attribute ASS_Renderer ass_renderer;
     attribute ASS_Library ass_library;
     void setLogLevel(long level);
+    void setDropAnimations(bool value);
+    bool getDropAnimations();
     void initLibrary(long frame_w, long frame_h);
     void createTrack(DOMString subfile);
     void createTrackMem(DOMString buf, unsigned long bufsize);
@@ -200,4 +202,5 @@ interface SubtitleOctopus {
     RenderBlendResult renderBlend(double tm, long force);
     double findNextEventStart(double tm);
     EventStopTimesResult findEventStopTimes(double tm);
+    void rescanAllAnimations();
 };

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -9,6 +9,7 @@ self.lastCurrentTimeReceivedAt = Date.now();
 self.targetFps = 30;
 self.libassMemoryLimit = 0; // in MiB
 self.renderOnDemand = false; // determines if only rendering on demand
+self.dropAllAnimations = false; // set to true to enable "lite mode" with all animations disabled for speed
 
 self.width = 0;
 self.height = 0;
@@ -597,6 +598,7 @@ function onMessageFromMainEmscriptenThread(message) {
             self.libassMemoryLimit = message.data.libassMemoryLimit || self.libassMemoryLimit;
             self.libassGlyphLimit = message.data.libassGlyphLimit || 0;
             self.renderOnDemand = message.data.renderOnDemand || false;
+            self.dropAllAnimations = message.data.dropAllAnimations || false;
             removeRunDependency('worker-init');
             break;
         }

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -95,6 +95,7 @@ Module['onRuntimeInitialized'] = function () {
     self.changed = Module._malloc(4);
 
     self.octObj.initLibrary(screen.width, screen.height);
+    self.octObj.setDropAnimations(!!self.dropAllAnimations);
     self.octObj.createTrack("/sub.ass");
     self.ass_track = self.octObj.track;
     self.ass_library = self.octObj.ass_library;

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -252,7 +252,7 @@ var SubtitlesOctopus = function (options) {
     self.setSubUrl = function (subUrl) {
         self.subUrl = subUrl;
     };
-    
+
     function _cleanPastRendered(currentTime, seekClean) {
         var retainedItems = [];
         for (var i = 0, len = self.renderedItems.length; i < len; i++) {
@@ -364,7 +364,7 @@ var SubtitlesOctopus = function (options) {
         var finishTime = -1, eventShown = false, animated = false;
         for (var i = 0, len = self.renderedItems.length; i < len; i++) {
             var item = self.renderedItems[i];
-            if (!eventShown && item.eventStart <= currentTime && (item.emptyFinish < 0 || item.emptyFinish >= currentTime)) {
+            if (!eventShown && item.eventStart <= currentTime && (item.emptyFinish < 0 || item.emptyFinish > currentTime)) {
                 _renderSubtitleEvent(item, currentTime);
                 eventShown = true;
                 finishTime = item.emptyFinish;
@@ -569,10 +569,13 @@ var SubtitlesOctopus = function (options) {
                             });
                             size += item.buffer.byteLength;
                         }
+
+                        var eventSplitted = false;
                         if ((data.emptyFinish > 0 && data.emptyFinish - data.eventStart < 1.0 / self.targetFps) || data.animated) {
                             var newFinish = data.eventStart + 1.0 / self.targetFps;
                             data.emptyFinish = newFinish;
                             data.eventFinish = newFinish;
+                            eventSplitted = true;
                         }
                         self.renderedItems.push({
                             eventStart: data.eventStart,
@@ -584,7 +587,7 @@ var SubtitlesOctopus = function (options) {
                             animated: data.animated,
                             size: size
                         });
-                        
+
                         self.renderedItems.sort(function (a, b) {
                             return a.eventStart - b.eventStart;
                         });
@@ -596,7 +599,7 @@ var SubtitlesOctopus = function (options) {
                             console.info('oneshot received "end of frames" event');
                         } else if (data.emptyFinish >= 0) {
                             // there's some more event to render, try requesting next event
-                            tryRequestOneshot(data.emptyFinish, data.animated);
+                            tryRequestOneshot(data.emptyFinish, eventSplitted);
                         } else {
                             console.info('there are no more events to prerender');
                         }

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -14,6 +14,7 @@ var SubtitlesOctopus = function (options) {
     var self = this;
     self.canvas = options.canvas; // HTML canvas element (optional if video specified)
     self.renderMode = options.renderMode || (options.lossyRender ? 'fast' : (options.blendRender ? 'blend' : 'normal'));
+    self.dropAllAnimations = options.dropAllAnimations || false;
     self.libassMemoryLimit = options.libassMemoryLimit || 0; // set libass bitmap cache memory limit in MiB (approximate)
     self.libassGlyphLimit = options.libassGlyphLimit || 0; // set libass glyph cache memory limit in MiB (approximate)
     self.targetFps = options.targetFps || 30;
@@ -122,7 +123,8 @@ var SubtitlesOctopus = function (options) {
             targetFps: self.targetFps,
             libassMemoryLimit: self.libassMemoryLimit,
             libassGlyphLimit: self.libassGlyphLimit,
-            renderOnDemand: self.renderAhead > 0
+            renderOnDemand: self.renderAhead > 0,
+            dropAllAnimations: self.dropAllAnimations
         });
     };
 


### PR DESCRIPTION
Also fix a case when rendered subtitles could have a "hole" (one or more frames with no subtitles when in reality there should have been subtitles).

Again reminding that `src/SubOctpInterface.js` and `src/SubOctpInterface.cpp` are generated.