### PR TITLE
Add options to limit subtitles rendered size

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -23,6 +23,7 @@ var SubtitlesOctopus = function (options) {
     self.prescaleTradeoff = options.prescaleTradeoff || null; // render subtitles less than viewport when less than 1.0 to improve speed, render to more than 1.0 to improve quality; set to null to disable scaling
     self.softHeightLimit = options.softHeightLimit || 1080; // don't apply prescaleTradeoff < 1 when viewport height is less that this limit
     self.hardHeightLimit = options.hardHeightLimit || 2160; // don't ever go above this limit
+    self.resizeVariation = options.resizeVariation || 0.2; // by how many a size can vary before it would cause clearance of prerendered buffer
 
     self.renderAhead = options.renderAhead || 0; // how many MiB to render ahead and store; 0 to disable (approximate)
     self.isOurCanvas = false; // (internal) we created canvas and manage it
@@ -403,10 +404,10 @@ var SubtitlesOctopus = function (options) {
     function resetRenderAheadCache() {
         if (self.renderAhead > 0) {
             if (self.oneshotState.prevHeight && self.oneshotState.prevWidth) {
-                if (self.canvas.height >= self.oneshotState.prevHeight * 0.8 &&
-                    self.canvas.height <= self.oneshotState.prevHeight * 1.2 &&
-                    self.canvas.width >= self.oneshotState.prevWidth * 0.8 &&
-                    self.canvas.width <= self.oneshotState.prevWidth * 1.2) {
+                if (self.canvas.height >= self.oneshotState.prevHeight * (1.0 - self.resizeVariation) &&
+                    self.canvas.height <= self.oneshotState.prevHeight * (1.0 + self.resizeVariation) &&
+                    self.canvas.width >= self.oneshotState.prevWidth * (1.0 - self.resizeVariation) &&
+                    self.canvas.width <= self.oneshotState.prevWidth * (1.0 + self.resizeVariation)) {
                     console.debug('not resetting prerender cache - keep using current');
                     // keep rendering canvas size the same,
                     // otherwise subtitles got placed incorrectly

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -46,7 +46,9 @@ var SubtitlesOctopus = function (options) {
         eventOver: false,
         iteration: 0,
         renderRequested: false,
-        requestNextTimestamp: -1
+        requestNextTimestamp: -1,
+        prevWidth: null,
+        prevHeight: null
     }
 
     self.hasAlphaBug = false;
@@ -394,11 +396,27 @@ var SubtitlesOctopus = function (options) {
 
     function resetRenderAheadCache() {
         if (self.renderAhead > 0) {
+            if (self.oneshotState.prevHeight && self.oneshotState.prevWidth) {
+                if (self.canvas.height >= self.oneshotState.prevHeight * 0.8 &&
+                    self.canvas.height <= self.oneshotState.prevHeight * 1.2 &&
+                    self.canvas.width >= self.oneshotState.prevWidth * 0.8 &&
+                    self.canvas.width <= self.oneshotState.prevWidth * 1.2) {
+                    console.debug('not resetting prerender cache - keep using current');
+                    // keep rendering canvas size the same,
+                    // otherwise subtitles got placed incorrectly
+                    self.canvas.width = self.oneshotState.prevWidth;
+                    self.canvas.height = self.oneshotState.prevHeight;
+                    return;
+                }
+            }
+
             console.info('resetting prerender cache');
             self.renderedItems = [];
             self.oneshotState.eventStart = null;
             self.oneshotState.iteration++;
             self.oneshotState.renderRequested = false;
+            self.oneshotState.prevHeight = self.canvas.height;
+            self.oneshotState.prevWidth = self.canvas.width;
 
             window.requestAnimationFrame(oneshotRender);
             tryRequestOneshot(undefined, true);

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -22,7 +22,7 @@ var SubtitlesOctopus = function (options) {
     self.targetFps = options.targetFps || 30;
     self.prescaleTradeoff = options.prescaleTradeoff || 1.0; // render subtitles less than viewport when less than 1.0 to improve speed, render to more than 1.0 to improve quality
     self.softHeightLimit = options.softHeightLimit || 1080; // don't apply prescaleTradeoff < 1 when viewport height is less that this limit
-    self.hardHeightLimit = options.hardHeightLimit || 1600; // don't ever go above this limit
+    self.hardHeightLimit = options.hardHeightLimit || 2160; // don't ever go above this limit
 
     self.renderAhead = options.renderAhead || 0; // how many MiB to render ahead and store; 0 to disable (approximate)
     self.isOurCanvas = false; // (internal) we created canvas and manage it

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -20,7 +20,7 @@ var SubtitlesOctopus = function (options) {
     self.libassMemoryLimit = options.libassMemoryLimit || 0; // set libass bitmap cache memory limit in MiB (approximate)
     self.libassGlyphLimit = options.libassGlyphLimit || 0; // set libass glyph cache memory limit in MiB (approximate)
     self.targetFps = options.targetFps || 30;
-    self.prescaleTradeoff = options.prescaleTradeoff || 1.0; // render subtitles less than viewport when less than 1.0 to improve speed, render to more than 1.0 to improve quality
+    self.prescaleTradeoff = options.prescaleTradeoff || null; // render subtitles less than viewport when less than 1.0 to improve speed, render to more than 1.0 to improve quality; set to null to disable scaling
     self.softHeightLimit = options.softHeightLimit || 1080; // don't apply prescaleTradeoff < 1 when viewport height is less that this limit
     self.hardHeightLimit = options.hardHeightLimit || 2160; // don't ever go above this limit
 
@@ -674,7 +674,12 @@ var SubtitlesOctopus = function (options) {
     };
 
     function _computeCanvasSize(width, height) {
-        if (self.prescaleTradeoff > 1) {
+        if (self.prescaleTradeoff === null) {
+            if (height > self.hardHeightLimit) {
+                width = width * self.hardHeightLimit / height;
+                height = self.hardHeightLimit;
+            }
+        } else if (self.prescaleTradeoff > 1) {
             if (height * self.prescaleTradeoff <= self.softHeightLimit) {
                 width *= self.prescaleTradeoff;
                 height *= self.prescaleTradeoff;


### PR DESCRIPTION
They would be displayed by stretching if needed (if they get too high in resolution).
This should allow some speed savings on slow devices.

Also don't reset prerender cache if subtitle canvas size didn't change too much.