### PR TITLE
Fix oneshot render

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -288,7 +288,8 @@ var SubtitlesOctopus = function (options) {
                     for (var i = 0, len = retainedItems.length; i < len; i++) {
                         var item = retainedItems[i];
                         size += item.size;
-                        if (size >= limit) break;
+                        // Remove the end marker (emptyFinish < 0) to allow re-rendering in case we already reached end-of-events
+                        if (size >= limit || item.emptyFinish < 0) break;
                         retain.push(item);
                     }
                     retainedItems = retain;

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -57,6 +57,7 @@ var SubtitlesOctopus = function (options) {
         prevWidth: null,
         prevHeight: null
     }
+    self.rafId = 0;
 
     self.hasAlphaBug = false;
 
@@ -375,7 +376,7 @@ var SubtitlesOctopus = function (options) {
     }
 
     function oneshotRender() {
-        window.requestAnimationFrame(oneshotRender);
+        self.rafId = window.requestAnimationFrame(oneshotRender);
         if (!self.video) return;
 
         var currentTime = self.video.currentTime + self.timeOffset;
@@ -407,6 +408,11 @@ var SubtitlesOctopus = function (options) {
         } else if (_cleanPastRendered(currentTime) && finishTime >= 0) {
             tryRequestOneshot(finishTime, animated);
         }
+    }
+
+    function stopOneshotRender() {
+        window.cancelAnimationFrame(self.rafId);
+        self.rafId = 0;
     }
 
     self.resetRenderAheadCache = function (isResizing) {
@@ -443,7 +449,7 @@ var SubtitlesOctopus = function (options) {
             self.oneshotState.prevHeight = self.canvas.height;
             self.oneshotState.prevWidth = self.canvas.width;
 
-            window.requestAnimationFrame(oneshotRender);
+            if (!self.rafId) self.rafId = window.requestAnimationFrame(oneshotRender);
             tryRequestOneshot(undefined, true);
         }
     }
@@ -856,6 +862,8 @@ var SubtitlesOctopus = function (options) {
         if (self.video) {
             self.video.parentNode.removeChild(self.canvasParent);
         }
+
+        stopOneshotRender();
     };
 
     self.createEvent = function (event) {


### PR DESCRIPTION
**Changes**
- Allow re-render after rewind.
- Stop requesting animation frame after `dispose`.

**Issues**
1. It keeps displaying the last displayed event if we rewind.
2. It keeps requesting animation frame after `dispose`.
