### PR TITLE
Fix last event

### DIFF
--- a/src/SubtitleOctopus.cpp
+++ b/src/SubtitleOctopus.cpp
@@ -555,7 +555,7 @@ public:
         if (minFinish != -1) {
             // some event is going on, so we need to re-draw either when it stops
             // or when some other event starts
-            result.eventFinish = ((minFinish < minStart) ? minFinish : minStart) / 1000.0;
+            result.eventFinish = ((minStart == -1 || minFinish < minStart) ? minFinish : minStart) / 1000.0;
         } else {
             // there's no current event, so no need to draw anything
             result.eventFinish = -1;

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -292,7 +292,7 @@ var SubtitlesOctopus = function (options) {
             }
         }
 
-        var removed = retainedItems.length < self.renderedItems;
+        var removed = retainedItems.length < self.renderedItems.length;
         self.renderedItems = retainedItems;
         return removed;
     }


### PR DESCRIPTION
**Changes**
- Fix last event
- Fix array comparison

**Issues**
- https://github.com/jellyfin/jellyfin-web/issues/3326
- I'm not sure what the effect of the broken array comparison is. Maybe the subtitles stop rendering.