### PR TITLE
Rework the cache reset when resize the canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ When creating an instance of SubtitleOctopus, you can set the following options:
                  (Default: `0` - don't render ahead)
 - `resizeVariation`: The resize threshold at which the cache of pre-rendered events is cleared.
                      (Default: `0.2`)
+- `renderAheadResetMinTime`: Minimum time in seconds to keep events in the cache after
+                             resizing the canvas (regardless of `resizeVariation`).
+                             (Default: `1`)
+- `renderAheadResetMaxTime`: Maximum time in seconds to keep events in the cache after
+                             resizing the canvas (within `resizeVariation`).
+                             (Default: `0`; `0` - no time limit)
+- `renderAheadResetMaxFill`: Maximum portion of the cache that can be used after
+                             resizing the canvas.
+                             (Default: `1`; `1` - the entire cache can be used)
 
 ### Rendering Modes
 #### JS Blending


### PR DESCRIPTION
**Changes**
- Extract the options.
- Compare the resolution of each frame with the current canvas size.
- Compare the subtitle display end time, not the gap end time. _The gap is invisible, after all._
- Keep some frames within specified time regardless of the resolution. _Equal to the 10s time limit in the old version._
- Discard distant frames if maximum time is specified. _Equal to the 30s time limit in the old version, but currently disabled by default._
- Reduce the guaranteed (minimum) display time (was 10s - the low-res frames are displayed for too long, now 1s).
- Disable size limit by default.

**Issues**
In theory (more for increasing the size):
Resizing the canvas with, say, 15% step, the old version keeps ~30s (if the size limit allows) of low-res frames instead of discarding them.