### PR TITLE
Add test samples for RenderAhead

### DIFF
--- a/aspect-ratio.html
+++ b/aspect-ratio.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -50,6 +51,8 @@
         <script src="https://vjs.zencdn.net/7.5.5/video.js"></script>
 
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = videojs('#test');
             player.ready(function () {
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
@@ -57,12 +60,12 @@
                 window.SubtitlesOctopusOnLoad = function () {
                     var options = {
                         video: video,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.ttf', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf'],
+                        subUrl: baseUrl + '/subtitles/test.ass',
+                        fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,15 @@
+/**
+ * Returns base URL.
+ * @returns {string} Base URL.
+ */
+ function getBaseUrl() {
+    var pathname = window.location.pathname;
+
+    var pos = pathname.lastIndexOf('/');
+
+    if (pos !== -1) {
+        pathname = pathname.slice(0, pos);
+    }
+
+    return window.location.origin + pathname;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -13,3 +13,62 @@
 
     return window.location.origin + pathname;
 }
+
+/**
+ * Supported render modes.
+ */
+var SUPPORTED_MODES = ['js-blend', 'wasm-blend', 'lossy'];
+
+/**
+ * Generates options according to the passed base options and URL search params.
+ * @param {Object} options - Base options.
+ * @returns {Object} Options.
+ */
+function makeOptions(options) {
+    var param = new URLSearchParams(window.location.search);
+
+    var renderMode = param.get('renderMode');
+    var renderAhead = param.get('renderAhead') || options.renderAhead;
+
+    if (!SUPPORTED_MODES.includes(renderMode)) {
+        renderMode = options.renderMode;
+    }
+
+    if (renderAhead > 0) {
+        // RenderAhead doesn't support other modes
+        renderMode = 'wasm-blend';
+        // Lock RenderAhead memory
+        renderAhead = 90;
+    } else {
+        renderAhead = 0;
+    }
+
+    return Object.assign({}, options, {
+        renderMode: renderMode,
+        renderAhead: renderAhead
+    });
+}
+
+/**
+ * Returns name of render mode.
+ * @param {SubtitleOctopus} octopus - SubtitleOctopus instance.
+ * @returns {string} Render mode name.
+ */
+function getRenderModeName(octopus) {
+    var renderAhead = '';
+
+    if (octopus.renderAhead > 0) {
+        renderAhead = '+RenderAhead';
+    }
+
+    switch (octopus.renderMode) {
+        case 'js-blend':
+            return 'JSRender' + renderAhead;
+        case 'wasm-blend':
+            return 'BlendRender' + renderAhead;
+        case 'lossy':
+            return 'LossyRender' + renderAhead;
+    }
+
+    throw 'Unsupported render mode';
+}

--- a/brotliSubTest.html
+++ b/brotliSubTest.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -50,6 +51,8 @@
         <script src="https://vjs.zencdn.net/7.5.5/video.js"></script>
 
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = videojs('#test');
             player.ready(function () {
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
@@ -58,12 +61,12 @@
                     var options = {
                         video: video,
                         lossyRender: true,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass.br',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.woff2', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.woff2'],
+                        subUrl: baseUrl + '/subtitles/test.ass.br',
+                        fonts: [baseUrl + '/fonts/Arial.woff2', baseUrl + '/fonts/TimesNewRoman.woff2'],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/clappr.html
+++ b/clappr.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -40,6 +41,8 @@
         <div id="player"></div>
         <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js"></script>
         <script>
+            var baseUrl = getBaseUrl();
+
             // Player Setup
             var playerElement = document.getElementById('player');
             var player = new Clappr.Player({
@@ -50,12 +53,12 @@
                     window.SubtitlesOctopusOnLoad = function() {
                         var options = {
                             video: video,
-                            subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                            fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.ttf', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf'],
+                            subUrl: baseUrl + '/subtitles/test.ass',
+                            fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
                             //onReady: onReadyFunction,
                             //debug: true,
-                            workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                            legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                            workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                            legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                         };
                         window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                     };

--- a/flowplayer.html
+++ b/flowplayer.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -46,18 +47,20 @@
         <script src="https://releases.flowplayer.org/7.2.7/flowplayer.min.js"></script>
         <link href="https://releases.flowplayer.org/7.2.7/skin/skin.css" rel="stylesheet">
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = $('.player');
             player.flowplayer({}).on("ready", function (e, api, video) {
                 var video = player.find('video')[0];
                 window.SubtitlesOctopusOnLoad = function() {
                     var options = {
                         video: video,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.ttf', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf'],
+                        subUrl: baseUrl + '/subtitles/test.ass',
+                        fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/fonts-map.html
+++ b/fonts-map.html
@@ -12,6 +12,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -44,22 +45,24 @@
         <script src="https://cdn.plyr.io/3.5.6/plyr.js"></script>
         <link rel="stylesheet" href="https://cdn.plyr.io/3.5.6/plyr.css">
         <script>
+            var baseUrl = getBaseUrl();
+
             const player = new Plyr('#player');
             player.on('ready', function () {
                 var video = document.getElementById('player');
                 window.SubtitlesOctopusOnLoad = function() {
                     var options = {
                         video: video,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
+                        subUrl: baseUrl + '/subtitles/test.ass',
                         availableFonts: {
-                          'arial': '/JavascriptSubtitlesOctopus/fonts/Arial.ttf', 
-                          'times new roman': '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf', 
+                          'arial': baseUrl + '/fonts/Arial.ttf',
+                          'times new roman': baseUrl + '/fonts/TimesNewRoman.ttf',
                           'for example this file wouldnt be used': '/nope.ttf'
                         }, // All available fonts (font name should be lower case). It will load only fonts really used in sub.
                         //onReady: onReadyFunction,
                         //debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
                 <a href="./railgun.html" class="list-group-item list-group-item-action">Railgun S Karaoke Test - BlendRender</a>
                 <a href="./railgun.html?renderMode=wasm-blend&renderAhead=1" class="list-group-item list-group-item-action">Railgun S Karaoke Test - BlendRender+RenderAhead</a>
                 <a href="./stress.html" class="list-group-item list-group-item-action">Attack on Titan Stress Karaoke Test - LossyRender</a>
+                <a href="./stress.html?renderMode=wasm-blend" class="list-group-item list-group-item-action">Attack on Titan Stress Karaoke Test - BlendRender</a>
                 <a href="./stress.html?renderMode=wasm-blend&renderAhead=1" class="list-group-item list-group-item-action">Attack on Titan Stress Karaoke Test - BlendRender+RenderAhead</a>
                 <a href="./aspect-ratio.html" class="list-group-item list-group-item-action">Aspect Ratio Test</a>
                 <a href="./fonts-map.html" class="list-group-item list-group-item-action">Fonts Map Test</a>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 
             <div class="list-group">
                 <a href="./videojs.html" class="list-group-item list-group-item-action">Video.JS</a>
+                <a href="./videojs.html?renderMode=wasm-blend&renderAhead=1" class="list-group-item list-group-item-action">Video.JS - BlendRender+RenderAhead</a>
                 <a href="./flowplayer.html" class="list-group-item list-group-item-action">Flowplayer</a>
                 <a href="./mediaelement.html" class="list-group-item list-group-item-action">MediaElement player with Multi-track</a>
                 <a href="./plyr.html" class="list-group-item list-group-item-action">Plyr player</a>
@@ -51,7 +52,9 @@
                 <a href="./native.html" class="list-group-item list-group-item-action">HTML5 Native player</a>
                 
                 <a href="./railgun.html" class="list-group-item list-group-item-action">Railgun S Karaoke Test - BlendRender</a>
+                <a href="./railgun.html?renderMode=wasm-blend&renderAhead=1" class="list-group-item list-group-item-action">Railgun S Karaoke Test - BlendRender+RenderAhead</a>
                 <a href="./stress.html" class="list-group-item list-group-item-action">Attack on Titan Stress Karaoke Test - LossyRender</a>
+                <a href="./stress.html?renderMode=wasm-blend&renderAhead=1" class="list-group-item list-group-item-action">Attack on Titan Stress Karaoke Test - BlendRender+RenderAhead</a>
                 <a href="./aspect-ratio.html" class="list-group-item list-group-item-action">Aspect Ratio Test</a>
                 <a href="./fonts-map.html" class="list-group-item list-group-item-action">Fonts Map Test</a>
                 <a href="./resize-observer.html" class="list-group-item list-group-item-action">Resize Observer Test</a>

--- a/mediaelement.html
+++ b/mediaelement.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -40,12 +41,14 @@
         
         <video width="800" height="480" controls="controls" preload="none">
             <source type="video/webm" src="https://animethemes.moe/video/ToaruKagakuNoRailgunS-OP1.webm" />
-            <track src="/JavascriptSubtitlesOctopus/subtitles/railgun_op.ass" srclang="en" label="English" kind="subtitles" type="application/x-ass">
-            <track src="/JavascriptSubtitlesOctopus/subtitles/test.ass" srclang="jp" label="Test Lang" kind="subtitles" type="application/x-ass">
+            <track src="./subtitles/railgun_op.ass" srclang="en" label="English" kind="subtitles" type="application/x-ass">
+            <track src="./subtitles/test.ass" srclang="jp" label="Test Lang" kind="subtitles" type="application/x-ass">
         </video>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/4.2.12/mediaelementplayer.min.css" integrity="sha256-ji1bfJaTGnyscoc7LzcV9yNJy5vGKJ0frO3KJo1oaGQ=" crossorigin="anonymous" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/4.2.12/mediaelement-and-player.min.js" integrity="sha256-z7JbZVaNbNzLvOCFHUNrjqnZRojZbRAxgr4KU2qL0qc=" crossorigin="anonymous"></script>
         <script>
+            var baseUrl = getBaseUrl();
+
             mejs.i18n.language('en');
 
             $('video').mediaelementplayer({
@@ -54,17 +57,19 @@
                     player.addEventListener('captionschange', function(e) {
                         console.log('Charging Track ' + e.detail.caption);
                         if (e.detail.caption !== null) {
+                            var subUrl = e.detail.caption.src.replace(/^\.\//, baseUrl + '/');
+
                             if (window.octopusInstance) {
-                                window.octopusInstance.setTrackByUrl(e.detail.caption.src);
+                                window.octopusInstance.setTrackByUrl(subUrl);
                             } else if (SubtitlesOctopus) {
                                 var options = {
                                     video: video,
-                                    subUrl: e.detail.caption.src,
-                                    fonts: ['/JavascriptSubtitlesOctopus/fonts/CabinCondensed-Regular.ttf', '/JavascriptSubtitlesOctopus/fonts/SourceSansPro-SemiBold.ttf'],
+                                    subUrl: subUrl,
+                                    fonts: [baseUrl + '/fonts/CabinCondensed-Regular.ttf', baseUrl + '/fonts/SourceSansPro-SemiBold.ttf'],
                                     //onReady: onReadyFunction,
                                     debug: true,
-                                    workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                                    legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                                    workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                                    legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                                 };
                                 window.octopusInstance = new SubtitlesOctopus(options);
                             }

--- a/native.html
+++ b/native.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -46,16 +47,18 @@
         Subtitles not shown in fullscreen when using with pure HTML5 video. Fullscreen working in any player with custom controls (<a href="videojs.html">see example with Video.js player</a>). <a href="https://github.com/Dador/JavascriptSubtitlesOctopus/issues/1#issuecomment-271834400">Why this happens?</a>
         <br><br><br>
         <script>
+            var baseUrl = getBaseUrl();
+
             var video = document.getElementById("player");
             window.SubtitlesOctopusOnLoad = function() {
                 var options = {
                     video: video,
-                    subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                    fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.ttf', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf'],
+                    subUrl: baseUrl + '/subtitles/test.ass',
+                    fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
                     //onReady: onReadyFunction,
                     //debug: true,
-                    workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                    legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                    workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                    legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                 };
                 window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
             };

--- a/plyr.html
+++ b/plyr.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -47,18 +48,20 @@
         <script src="https://cdn.plyr.io/3.5.6/plyr.js"></script>
         <link rel="stylesheet" href="https://cdn.plyr.io/3.5.6/plyr.css">
         <script>
+            var baseUrl = getBaseUrl();
+
             const player = new Plyr('#player');
             player.on('ready', function () {
                 var video = document.getElementById('player');
                 window.SubtitlesOctopusOnLoad = function() {
                     var options = {
                         video: video,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.ttf', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf'],
+                        subUrl: baseUrl + '/subtitles/test.ass',
+                        fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
                         //onReady: onReadyFunction,
                         //debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/railgun.html
+++ b/railgun.html
@@ -38,7 +38,8 @@
 
     <div id="content" style="padding-top: 25px;">
       <div id="main" class="container container-body">
-        <h1>Toaru Kagaku no Railgun S (Spring 2013) Karaoke Test - BlendRenderer</h1>
+        <h1>Toaru Kagaku no Railgun S (Spring 2013) Karaoke Test</h1>
+        <h2 id="renderMode"></h2>
         
         <video id="test" class="video-js" controls preload="auto" width="840" height="460" data-setup="{}">
             <source src="https://animethemes.moe/video/ToaruKagakuNoRailgunS-OP1.webm" type='video/webm'>
@@ -74,7 +75,7 @@
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
                 var video = this.tech_.el_;
                 window.SubtitlesOctopusOnLoad = function () {
-                    var options = {
+                    var options = makeOptions({
                         video: video,
                         renderMode: 'wasm-blend',
                         subUrl: baseUrl + '/subtitles/railgun_op.ass.br',
@@ -86,8 +87,10 @@
                         debug: true,
                         workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
                         legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
-                    };
+                    });
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
+
+                    document.querySelector('#renderMode').innerText = getRenderModeName(window.octopusInstance);
                 };
                 if (SubtitlesOctopus) {
                     SubtitlesOctopusOnLoad();

--- a/railgun.html
+++ b/railgun.html
@@ -14,6 +14,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/resize-observer-polyfill@1.5.1/dist/ResizeObserver.js" integrity="sha384-yEkffEbxKzcF3QBOfMbXxFh46kJHWkiO7flPoOfivtspG0m0zxWg6uzHQTSgjlVT" crossorigin="anonymous"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -66,6 +67,8 @@
         <script src="https://vjs.zencdn.net/7.5.5/video.js"></script>
 
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = videojs('#test');
             player.ready(function () {
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
@@ -74,13 +77,15 @@
                     var options = {
                         video: video,
                         renderMode: 'wasm-blend',
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/railgun_op.ass.br',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/SourceSansPro-SemiBold.woff2', 
-                        '/JavascriptSubtitlesOctopus/fonts/CabinCondensed-Regular.woff2'],
+                        subUrl: baseUrl + '/subtitles/railgun_op.ass.br',
+                        fonts: [
+                            baseUrl + '/fonts/SourceSansPro-SemiBold.woff2',
+                            baseUrl + '/fonts/CabinCondensed-Regular.woff2'
+                        ],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/resize-observer.html
+++ b/resize-observer.html
@@ -14,6 +14,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/resize-observer-polyfill@1.5.1/dist/ResizeObserver.js" integrity="sha384-yEkffEbxKzcF3QBOfMbXxFh46kJHWkiO7flPoOfivtspG0m0zxWg6uzHQTSgjlVT" crossorigin="anonymous"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -63,6 +64,8 @@
         <script src="https://vjs.zencdn.net/7.5.5/video.js"></script>
 
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = videojs('#test');
             player.ready(function () {
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
@@ -70,12 +73,12 @@
                 window.SubtitlesOctopusOnLoad = function () {
                     var options = {
                         video: video,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.ttf', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf'],
+                        subUrl: baseUrl + '/subtitles/test.ass',
+                        fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/stress.html
+++ b/stress.html
@@ -14,6 +14,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/resize-observer-polyfill@1.5.1/dist/ResizeObserver.js" integrity="sha384-yEkffEbxKzcF3QBOfMbXxFh46kJHWkiO7flPoOfivtspG0m0zxWg6uzHQTSgjlVT" crossorigin="anonymous"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -66,6 +67,8 @@
         <script src="https://vjs.zencdn.net/7.5.5/video.js"></script>
 
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = videojs('#test');
             player.ready(function () {
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
@@ -74,21 +77,21 @@
                     var options = {
                         video: video,
                         renderMode: 'lossy',
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/aot3p2_op.ass.br',
+                        subUrl: baseUrl + '/subtitles/aot3p2_op.ass.br',
                         fonts: [
-                            '/JavascriptSubtitlesOctopus/fonts/1_ANGIE-BOLD.woff2', 
-                            '/JavascriptSubtitlesOctopus/fonts/2_ANGIE-BOLDITALIC.woff2',
-                            '/JavascriptSubtitlesOctopus/fonts/3_BSOD.woff2', 
-                            '/JavascriptSubtitlesOctopus/fonts/4_CLEARFACESSIBOLD.woff2',
-                            '/JavascriptSubtitlesOctopus/fonts/5_IM_FELL_ENGLISH_PRO_ROMAN.woff2', 
-                            '/JavascriptSubtitlesOctopus/fonts/6_INSIGNESPLATS!-REGULAR.woff2',
-                            '/JavascriptSubtitlesOctopus/fonts/7_KINESISSTD-BLACK.woff2', 
-                            '/JavascriptSubtitlesOctopus/fonts/8_AGARAMONDPRO-REGULAR.woff2',
+                            baseUrl + '/fonts/1_ANGIE-BOLD.woff2',
+                            baseUrl + '/fonts/2_ANGIE-BOLDITALIC.woff2',
+                            baseUrl + '/fonts/3_BSOD.woff2',
+                            baseUrl + '/fonts/4_CLEARFACESSIBOLD.woff2',
+                            baseUrl + '/fonts/5_IM_FELL_ENGLISH_PRO_ROMAN.woff2',
+                            baseUrl + '/fonts/6_INSIGNESPLATS!-REGULAR.woff2',
+                            baseUrl + '/fonts/7_KINESISSTD-BLACK.woff2',
+                            baseUrl + '/fonts/8_AGARAMONDPRO-REGULAR.woff2',
                         ],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/stress.html
+++ b/stress.html
@@ -38,7 +38,8 @@
 
     <div id="content" style="padding-top: 25px;">
       <div id="main" class="container container-body">
-        <h1>Attack on Titan Season 3 Part 2 (Spring 2019) Stress Karaoke Test - LossyRender</h1>
+        <h1>Attack on Titan Season 3 Part 2 (Spring 2019) Stress Karaoke Test</h1>
+        <h2 id="renderMode"></h2>
         
         <video id="test" class="video-js" controls preload="auto" width="840" height="460" data-setup="{}">
             <source src="https://animethemes.moe/video/ShingekiNoKyojinS3Part2-OP1-NCBD1080.webm" type='video/webm'>
@@ -74,7 +75,7 @@
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
                 var video = this.tech_.el_;
                 window.SubtitlesOctopusOnLoad = function () {
-                    var options = {
+                    var options = makeOptions({
                         video: video,
                         renderMode: 'lossy',
                         subUrl: baseUrl + '/subtitles/aot3p2_op.ass.br',
@@ -92,8 +93,10 @@
                         debug: true,
                         workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
                         legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
-                    };
+                    });
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
+
+                    document.querySelector('#renderMode').innerText = getRenderModeName(window.octopusInstance);
                 };
                 if (SubtitlesOctopus) {
                     SubtitlesOctopusOnLoad();

--- a/videojs.html
+++ b/videojs.html
@@ -38,6 +38,7 @@
     <div id="content" style="padding-top: 25px;">
       <div id="main" class="container container-body">
         <h1>Video.JS Player Example</h1>
+        <h2 id="renderMode"></h2>
         
         <video id="test" class="video-js" controls preload="auto" width="840" height="460" data-setup="{}">
             <source src="https://mirror.clarkson.edu/blender/demo/movies/BBB/bbb_sunflower_1080p_30fps_normal.mp4" type='video/mp4'>
@@ -58,7 +59,7 @@
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
                 var video = this.tech_.el_;
                 window.SubtitlesOctopusOnLoad = function () {
-                    var options = {
+                    var options = makeOptions({
                         video: video,
                         subUrl: baseUrl + '/subtitles/test.ass',
                         fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
@@ -66,8 +67,10 @@
                         debug: true,
                         workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
                         legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
-                    };
+                    });
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
+
+                    document.querySelector('#renderMode').innerText = getRenderModeName(window.octopusInstance);
                 };
                 if (SubtitlesOctopus) {
                     SubtitlesOctopusOnLoad();

--- a/videojs.html
+++ b/videojs.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -50,6 +51,8 @@
         <script src="https://vjs.zencdn.net/7.5.5/video.js"></script>
 
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = videojs('#test');
             player.ready(function () {
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
@@ -57,12 +60,12 @@
                 window.SubtitlesOctopusOnLoad = function () {
                     var options = {
                         video: video,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.ttf', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.ttf'],
+                        subUrl: baseUrl + '/subtitles/test.ass',
+                        fonts: [baseUrl + '/fonts/Arial.ttf', baseUrl + '/fonts/TimesNewRoman.ttf'],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };

--- a/woffTest.html
+++ b/woffTest.html
@@ -13,6 +13,7 @@
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
     <script src="./assets/js/subtitles-octopus.js"></script>
+    <script src="./assets/js/main.js"></script>
 </head>
 
 <body>
@@ -50,6 +51,8 @@
         <script src="https://vjs.zencdn.net/7.5.5/video.js"></script>
 
         <script>
+            var baseUrl = getBaseUrl();
+
             var player = videojs('#test');
             player.ready(function () {
                 // This would look more nice as a plugin but is's just as showcase of using with custom players
@@ -57,12 +60,12 @@
                 window.SubtitlesOctopusOnLoad = function () {
                     var options = {
                         video: video,
-                        subUrl: '/JavascriptSubtitlesOctopus/subtitles/test.ass',
-                        fonts: ['/JavascriptSubtitlesOctopus/fonts/Arial.woff2', '/JavascriptSubtitlesOctopus/fonts/TimesNewRoman.woff2'],
+                        subUrl: baseUrl + '/subtitles/test.ass',
+                        fonts: [baseUrl + '/fonts/Arial.woff2', baseUrl + '/fonts/TimesNewRoman.woff2'],
                         //onReady: onReadyFunction,
                         debug: true,
-                        workerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker.js',
-                        legacyWorkerUrl: '/JavascriptSubtitlesOctopus/assets/js/subtitles-octopus-worker-legacy.js'
+                        workerUrl: baseUrl + '/assets/js/subtitles-octopus-worker.js',
+                        legacyWorkerUrl: baseUrl + '/assets/js/subtitles-octopus-worker-legacy.js'
                     };
                     window.octopusInstance = new SubtitlesOctopus(options); // You can experiment in console
                 };


### PR DESCRIPTION
_Inspired by https://github.com/libass/JavascriptSubtitlesOctopus/issues/136_

**Changes**
- Add BaseUrl support
- Configure JSO via URL search params
- Add test samples for RenderAhead
- Add stress test for BlendRender
