### PR TITLE
[TheOneric] Deprecate manual brotli decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,16 @@ Adjusting `prescaleFactor`, `prescaleHeightLimit` and `maxRenderHeight` to lower
 the rendering canvas can work around this at the expense of visual quality.
 
 
-### Brotli Compressed Subtitles
-The SubtitleOctopus allow the use of compressed subtitles in brotli format,
-saving bandwidth and reducing library startup time
+### Brotli Compressed Subtitles (DEPRECATED)
+Manual support for brotli-compressed subtitles is tentatively deprecated
+and may be removed with the next release.
 
-To use, just run: `brotli subFile.ass` and use the .br result file with the subUrl option
+Instead use HTTP's `Content-Encoding:` header to transmit files compressed and
+let the browser handle decompression before it reaches JSO. This supports more
+compression algorithms and is likely faster.
+Do not use a `.br` file extension if you use `Content-Ecoding:` as this will
+conflict with the still existing manual support which tries to decompress any data
+with a `.br` extension.
 
 ## How to build?
 

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -45,7 +45,13 @@ function isBrotliFile(url) {
         len = url.length;
     }
 
-    return url.endsWith(".br", len);
+    if (url.endsWith(".br", len)) {
+        console.warn("Support for manual brotli decompression is tentatively deprecated and "
+                + "may be removed with the next release. Instead use HTTP's Content-Encoding.")
+        return true;
+    }
+
+    return false;
 }
 
 Module = Module || {};


### PR DESCRIPTION
_Pulling from the upstream._
_Original author: TheOneric_

Non-PRed [commit](https://github.com/libass/JavascriptSubtitlesOctopus/commit/e459c8e6ffa83f2244f9745f54c39a19edd9684f).
