### PR TITLE
Fix resetting scheduled request

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -689,9 +689,14 @@ var SubtitlesOctopus = function (options) {
                                     data.eventStart + ', empty=' + data.emptyFinish +
                                     '), render: ' + Math.round(data.spentTime) + ' ms');
                         }
+
+                        var requestNextTimestamp = self.oneshotState.requestNextTimestamp;
+
                         self.oneshotState.renderRequested = false;
-                        if (Math.abs(data.lastRenderedTime - self.oneshotState.requestNextTimestamp) < EVENTTIME_ULP) {
-                            self.oneshotState.requestNextTimestamp = -1;
+                        self.oneshotState.requestNextTimestamp = -1;
+
+                        if (Math.abs(data.lastRenderedTime - requestNextTimestamp) < EVENTTIME_ULP) {
+                            requestNextTimestamp = -1;
                         }
                         if (data.eventStart - data.lastRenderedTime > EVENTTIME_ULP) {
                             // generate bogus empty element, so all timeline is covered anyway
@@ -745,9 +750,9 @@ var SubtitlesOctopus = function (options) {
                             return a.eventStart - b.eventStart;
                         });
 
-                        if (self.oneshotState.requestNextTimestamp >= 0) {
+                        if (requestNextTimestamp >= 0) {
                             // requesting an out of order event render
-                            tryRequestOneshot(self.oneshotState.requestNextTimestamp, true);
+                            tryRequestOneshot(requestNextTimestamp, true);
                         } else if (data.eventStart < 0) {
                             console.info('oneshot received "end of frames" event');
                         } else if (data.emptyFinish >= 0) {


### PR DESCRIPTION
**Changes**
Reset scheduled request as soon as we are ready to process it.

**Issues**
A scheduled request isn't reset when we [skip a covered time](https://github.com/jellyfin/JavascriptSubtitlesOctopus/blob/5b330a76030d55dcd6a5406cb283aa3069b0f522/src/subtitles-octopus.js#L362-L368) and will be resubmitted unless another time is requested. Thus, we should reset it as soon as we are ready to process it.
