### PR TITLE
Remove time offset of render request

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -370,12 +370,11 @@ var SubtitlesOctopus = function (options) {
         }
 
         if (size <= self.renderAhead) {
-            var lastRendered = currentTime - (renderNow ? 0 : FRAMETIME_ULP);
             if (!self.oneshotState.renderRequested) {
                 self.oneshotState.renderRequested = true;
                 self.worker.postMessage({
                     target: 'oneshot-render',
-                    lastRendered: lastRendered,
+                    lastRendered: currentTime,
                     renderNow: renderNow,
                     iteration: self.oneshotState.iteration
                 });
@@ -383,7 +382,7 @@ var SubtitlesOctopus = function (options) {
                 if (self.workerActive) {
                     console.info('worker busy, requesting to seek');
                 }
-                self.oneshotState.requestNextTimestamp = lastRendered;
+                self.oneshotState.requestNextTimestamp = currentTime;
             }
         }
     }


### PR DESCRIPTION
**Changes**
- Remove time offset of render request.
This may cause the series of events to shift due to the forced prolongation of each short (less than frame time) event.
This is probably a hack to avoid floating point representation errors, and since time rounding is added, it is no longer needed.

**Issues**
N/A