### PR TITLE
Discard events by display time span, not by gap between them

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -540,7 +540,7 @@ var SubtitlesOctopus = function (options) {
                 var size = 0;
                 for (var i = 0; i < self.renderedItems.length; i++) {
                     var item = self.renderedItems[i];
-                    if (item.emptyFinish < 0 || stopTime < item.emptyFinish) break;
+                    if (item.emptyFinish < 0 || stopTime < item.eventFinish) break;
                     size += item.size;
                     if (size >= sizeLimit) break;
                     newCache.push(item);


### PR DESCRIPTION
By discarding events by `emptyFinish`, we force JSO to re-render the "good" event, followed by a gap `[eventFinish..emptyFinish]`.

**Changes**
Discard events by display time span, not by gap between them.

**Issues**
N/A
