### PR TITLE
Update CI dependencies

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -17,7 +17,7 @@ jobs:
           all_but_latest: true
 
     - name: Checkout Base Repo
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Checkout Submodules
       run: |
@@ -33,7 +33,7 @@ jobs:
         docker run --rm --env LC_ALL=C.UTF-8 -v "${PWD}":/code libass/jso:latest
 
     - name: Upload Nightly Build
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/master'
       with:
         name: js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Checkout submodules
       run: |
@@ -28,7 +28,7 @@ jobs:
         docker run --rm --env LC_ALL=C.UTF-8 -v "${PWD}":/code libass/jso:latest
 
     - name: Setup node environment for NPM
-      uses: actions/setup-node@v4.0.2
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 24
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
_Since we need to first decide [how to enable Renovate](https://github.com/jellyfin/JavascriptSubtitlesOctopus/pull/64#issuecomment-3689375433) on this repo, porting the [PR](https://github.com/dmitrylyzo/JavascriptSubtitlesOctopus/pull/8) manually._

More info https://github.com/dmitrylyzo/JavascriptSubtitlesOctopus/pull/8