### PR TITLE
Fix npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - v*
 
+permissions:
+  id-token: write  # Required for OIDC (npm trusted publishing)
+  contents: read
+
 jobs:
   build:
     name: Build & Publish to NPM


### PR DESCRIPTION
According to https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow:
> The critical requirement is the `id-token: write` permission, which allows GitHub Actions to generate OIDC tokens.